### PR TITLE
feat(graph): Graph editor with hierarchical composition and new data types

### DIFF
--- a/.claude/agents/quality-checker.md
+++ b/.claude/agents/quality-checker.md
@@ -1,0 +1,68 @@
+---
+name: quality-checker
+---
+
+# Quality Checker Agent
+
+Verifies code quality after implementation.
+
+## Scope
+
+All crates in the workspace.
+
+## Checks to Perform
+
+### 1. Build Check
+
+```bash
+cargo build --workspace --all-targets
+```
+
+### 2. Run Tests
+
+```bash
+cargo test --workspace
+```
+
+### 3. Clippy Lints
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+### 4. Format Check (Optional)
+
+```bash
+cargo fmt --check
+```
+
+## Reporting
+
+Report results in the following format:
+
+```markdown
+## Quality Check Results
+
+### Build
+- [ ] Pass / [ ] Fail
+
+### Tests
+- Total: X
+- Passed: X
+- Failed: X
+
+### Clippy
+- Warnings: X
+- Errors: X
+
+### Issues Found
+1. {issue description} - {file:line}
+2. ...
+```
+
+## On Failure
+
+If any check fails:
+1. Report the specific errors
+2. Suggest fixes if possible
+3. Do not proceed until issues are resolved

--- a/.claude/agents/refactor.md
+++ b/.claude/agents/refactor.md
@@ -1,0 +1,124 @@
+---
+name: refactor
+---
+
+# Refactor Agent
+
+Performs code refactoring across the Geolis CAD kernel codebase.
+
+## Scope
+
+All crates in the workspace.
+
+## Before Starting
+
+1. Understand current code structure
+2. Identify all affected files
+3. Plan the refactoring strategy
+4. Verify doc-code consistency - Check if implementation matches documentation
+
+## Current Architecture
+
+The codebase follows a layered architecture for the CAD kernel:
+
+### Layers
+
+| Layer | Responsibility | Description |
+|-------|----------------|-------------|
+| Geometry Layer | Mathematical representation | NURBS curves/surfaces, points, vectors |
+| Topology Layer | Connectivity management | Vertex, Edge, Loop, Face, Shell, Solid (BRep) |
+| Operations Layer | Shape manipulation | Extrude, Revolve, Trim, Boolean, Offset |
+| Math Foundation | Linear algebra | nalgebra-based vectors and matrices |
+
+### Key Design Principles
+
+- **Separation of Geometry and Topology** - Mathematical shape definitions are separate from connectivity
+- **Incremental API** - Use only the features you need
+- **Reliability-focused** - Numerical stability and topology consistency validation
+
+## Refactoring Types
+
+### Rename
+
+- Variables, functions, types, modules
+- Update all references across crates
+- Update documentation if needed
+
+### Extract
+
+- Extract function/method from large code blocks
+- Extract module from large files
+- Extract trait from common behavior
+
+### Move
+
+- Move types between modules/crates
+- Update imports and visibility
+- Ensure proper module hierarchy
+
+### Simplify
+
+- Remove dead code
+- Reduce complexity
+- Consolidate duplicate logic
+
+### Restructure
+
+- Reorganize module structure
+- Split or merge files
+- Improve code organization
+
+## Process
+
+1. **Analyze**: Identify all affected locations
+
+   ```bash
+   cargo check --workspace --all-targets 2>&1
+   ```
+
+2. **Plan**: List all changes to be made
+
+3. **Execute**: Make changes systematically
+
+4. **Verify**: Ensure build and tests pass
+
+   ```bash
+   cargo build --workspace --all-targets
+   cargo test --workspace
+   cargo clippy --workspace --all-targets
+   ```
+
+## Principles
+
+- **Loose coupling** - Make code testable with clear boundaries
+- **Single Responsibility** - Each module/type has one reason to change
+- **Proper file organization** - Split files appropriately by concern
+- **Clear naming** - Use descriptive, intention-revealing names
+- **Remove redundancy** - Eliminate duplicate or dead code
+- **Optimize performance** - Improve efficiency where possible
+
+### Rust-Specific
+
+- **Error handling** - Use proper error types, `Result`, avoid `unwrap`/`expect`
+- **Type safety** - Leverage Rust's type system, use newtype pattern
+- **Lifetime management** - Reduce unnecessary `.clone()`, use proper borrowing
+- **Visibility** - Use appropriate `pub`/`pub(crate)`/private visibility
+
+## Guidelines
+
+- Make atomic, focused changes
+- Preserve existing behavior (no functional changes)
+- Update tests if signatures change
+- Keep commit history clean (logical commits)
+- Verify documentation matches implementation before refactoring
+- Suggest additional improvements if identified
+
+## After Completion
+
+1. Run quality-checker agent to verify:
+
+   - Build succeeds
+   - All tests pass
+   - No clippy warnings
+
+2. Add test cases for refactored code

--- a/.claude/commands/dev-implement.md
+++ b/.claude/commands/dev-implement.md
@@ -1,0 +1,68 @@
+# Dev Implement
+
+Implement a feature or change in the Geolis codebase.
+
+## Input
+
+$ARGUMENTS
+
+Required: File path, directory, or description of what to implement.
+
+## Instructions
+
+### 1. Analyze Target
+
+Determine which area of the codebase the implementation targets:
+
+| Target Area | Description |
+|-------------|-------------|
+| Geometry | Curves, surfaces, points (NURBS, Bezier, etc.) |
+| Topology | BRep structure (Vertex, Edge, Loop, Face, Shell, Solid) |
+| Operations | Shape manipulation (Extrude, Boolean, Offset, etc.) |
+| Tessellation | Mesh generation for display |
+| Math | Foundation math utilities (nalgebra-based) |
+
+If the target spans multiple areas, determine the primary area and note dependencies.
+
+### 2. Implement
+
+Based on the analysis:
+
+1. Understand the implementation task description
+2. Identify specific files to modify (if known)
+3. Follow the layered architecture (Math -> Geometry -> Topology -> Operations)
+4. Implement in dependency order
+
+### 3. Post-Implementation
+
+After implementation:
+
+1. **Run `quality-checker`** to verify:
+   - Build succeeds
+   - Tests pass
+   - No clippy warnings
+
+2. **Ask user about documentation**:
+   > Implementation complete. Would you like to update documentation?
+
+## Examples
+
+```bash
+# Implement geometry
+/dev-implement Add NURBS curve evaluation
+
+# Implement topology
+/dev-implement Add half-edge data structure for BRep
+
+# Implement operation
+/dev-implement Add extrude operation for Face to Solid
+
+# Implement with file path
+/dev-implement src/geometry/curve/nurbs.rs
+```
+
+## Notes
+
+- If the target is unclear, ask the user for clarification
+- For cross-layer changes, implement in dependency order (math -> geometry -> topology -> operations)
+- Follow Rust coding rules from `.claude/rules/rust-coding.md`

--- a/.claude/commands/doc-config.md
+++ b/.claude/commands/doc-config.md
@@ -1,0 +1,79 @@
+# Doc Config
+
+Update Claude Code configuration files (agents, commands).
+
+## Input
+
+$ARGUMENTS
+
+Optional: Specific area to update (e.g., `agents`, `commands`).
+If not provided, checks all configuration files.
+
+## Instructions
+
+### 1. Analyze Current State
+
+Check for updates needed in `.claude/` directory:
+
+```bash
+ls -la .claude/agents/
+ls -la .claude/commands/
+ls -la .claude/rules/
+```
+
+### 2. Verify Configuration
+
+1. Verify agent scopes match current project structure
+2. Ensure commands use correct agent names
+3. Identify outdated patterns or examples
+
+### 3. Common Update Triggers
+
+Update configs when:
+
+| Trigger | What to Update |
+|---------|----------------|
+| New crate added | Update agent scopes |
+| Directory restructured | Update agent scopes |
+| New patterns established | Update code examples in agents |
+| Workflow changed | Update command instructions |
+
+### 4. Report Changes
+
+After updates, display summary:
+
+```markdown
+## Config Update Summary
+
+### Updated Files
+- `.claude/agents/quality-checker.md`
+  - Updated scope to include new crate
+
+### No Changes Needed
+- `.claude/commands/git-commit.md` - Already up to date
+
+### New Files Created
+- `.claude/agents/new-agent.md` - For new module
+
+### Recommendations
+- Consider adding agent for {new topic}
+```
+
+## Examples
+
+```bash
+# Update all configs
+/doc-config
+
+# Update only agents
+/doc-config agents
+
+# Update after adding new crate
+/doc-config Added new crate geolis_tessellation
+```
+
+## Notes
+
+- Run this after significant project structure changes
+- Keeps agent/command definitions in sync with codebase
+- Does not modify source code, only `.claude/` configuration

--- a/.claude/commands/doc-update.md
+++ b/.claude/commands/doc-update.md
@@ -1,0 +1,30 @@
+# Doc Update
+
+Manually trigger documentation update based on recent code changes.
+
+## Input
+
+$ARGUMENTS
+
+Optional: Specify a commit range or branch to analyze (e.g., `HEAD~5`, `feature-branch`).
+If not provided, analyzes changes from the last commit.
+
+## Instructions
+
+1. Analyze code changes in the specified scope
+2. Identify affected documentation (README, design docs, API docs)
+3. Update documentation to match code
+4. Report what was updated
+
+## Usage Examples
+
+```bash
+# Update docs based on last commit
+/doc-update
+
+# Update docs for last 5 commits
+/doc-update HEAD~5
+
+# Update docs for changes in a branch
+/doc-update feature/nurbs-curves
+```

--- a/.claude/commands/git-commit.md
+++ b/.claude/commands/git-commit.md
@@ -1,0 +1,121 @@
+# Git Commit Message
+
+Generate a commit message based on staged changes.
+
+## Instructions
+
+### 1. Check Staged Changes
+
+```bash
+# Show staged files
+git diff --cached --name-only
+
+# Show staged diff
+git diff --cached
+```
+
+### 2. Analyze Changes
+
+Based on the staged diff, determine:
+
+- **Type**: What kind of change is this?
+  - `feat`: New feature
+  - `fix`: Bug fix
+  - `refactor`: Code refactoring (no functional change)
+  - `perf`: Performance improvement
+  - `docs`: Documentation only
+  - `test`: Adding or updating tests
+  - `chore`: Build, CI, or other maintenance
+  - `style`: Code style/formatting (no functional change)
+
+- **Scope**: Which part of the codebase? (optional)
+  - `geometry`, `topology`, `operations`, `tessellation`, `math`
+
+- **Summary**: One-line description of what changed (imperative mood)
+
+- **Body**: Detailed explanation if needed (optional)
+
+### 3. Generate Commit Message
+
+Output the commit message in this format:
+
+```
+<type>(<scope>): <summary>
+
+<body (optional, explain why if not obvious)>
+```
+
+### 4. Output
+
+Write the output to `.ai/outputs/git.md` file (overwrite if exists).
+
+Format:
+
+```markdown
+# Commit Message
+
+**Generated:** {timestamp}
+
+## Message
+
+{the generated message}
+
+## Staged Files
+
+{list of staged files}
+
+## Command
+
+\`\`\`bash
+git commit -m "$(cat <<'EOF'
+{message}
+EOF
+)"
+\`\`\`
+```
+
+After writing the file, display a brief summary to the user:
+
+```text
+Wrote commit message to .ai/outputs/git.md
+
+- Type: {type}
+- Staged files: {count}
+```
+
+**IMPORTANT:** The `## Command` section MUST always be included in the output file. The command must use a HEREDOC format to correctly handle multi-line commit messages.
+
+## Guidelines
+
+- Summary should be 50 characters or less
+- Use imperative mood ("Add feature" not "Added feature")
+- Don't end summary with a period
+- Body should wrap at 72 characters
+- Focus on "what" and "why", not "how"
+- If multiple unrelated changes are staged, suggest splitting into separate commits
+- **DO NOT** include "Generated with [Claude Code]" or "Co-Authored-By: Claude" footer
+- Output only the commit title and body, nothing else
+
+## Examples
+
+Single file change:
+
+```text
+feat(geometry): Add NURBS curve evaluation
+```
+
+Multiple related changes:
+
+```text
+feat(topology): Implement BRep half-edge structure
+
+- Add HalfEdge type with twin/next/prev pointers
+- Implement Face boundary traversal
+- Add topology consistency validation
+```
+
+Refactoring:
+
+```text
+refactor(operations): Extract boolean operation into trait
+```

--- a/.claude/commands/git-issue.md
+++ b/.claude/commands/git-issue.md
@@ -1,0 +1,71 @@
+# Git Issue
+
+Create a new GitHub issue for a feature, bug fix, or other task.
+
+## Input
+
+$ARGUMENTS
+
+## Instructions
+
+Based on the input above, perform the following steps:
+
+### 1. Parse Issue Details
+
+Determine from the input:
+- **Title**: Short title (e.g., "NURBS Curve Evaluation")
+- **Type**: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`
+- **Scope**: `geometry`, `topology`, `operations`, `tessellation`, `math`
+- **Description**: One-line description of what this issue addresses
+- **Tasks**: Checklist of implementation subtasks (optional)
+- **Labels**: `enhancement`, `bug`, `performance`, `refactor` (default: `enhancement`)
+
+### 2. Create the Issue
+
+Execute the following command to create the GitHub issue:
+
+```bash
+gh issue create \
+  --title "{type}({scope}): {title}" \
+  --label "{label}" \
+  --body "$(cat <<'EOF'
+## Description
+
+{description}
+
+## Tasks
+
+- [ ] {task 1}
+- [ ] {task 2}
+...
+
+## Related
+
+- {related items if any}
+EOF
+)"
+```
+
+### 3. Output Summary
+
+Output a brief summary:
+- Issue number created
+- Title
+- Link to the issue
+
+## Examples
+
+```bash
+# Create a feature issue
+/git-issue feat geometry NURBS Curve Evaluation - Implement curve point evaluation
+
+# Create a bug fix issue
+/git-issue fix topology Half-edge twin pointer not set correctly
+
+# Create a refactor issue
+/git-issue refactor operations Simplify extrude operation error handling
+```
+
+Output:
+- Creates issue with title "feat(geometry): NURBS Curve Evaluation"
+- Returns issue number and link

--- a/.claude/commands/git-pr.md
+++ b/.claude/commands/git-pr.md
@@ -1,0 +1,126 @@
+# Git PR Description
+
+Generate a PR description based on the current branch's linked issue and commits.
+
+## Instructions
+
+### 1. Get Current Branch and Issue
+
+Extract the issue number from the current branch name.
+
+```bash
+# Get current branch name
+git branch --show-current
+```
+
+Branch naming pattern: `{issue-number}-{description}` (e.g., `12-feat-geometry-nurbs-curve`)
+
+### 2. Fetch Issue Details
+
+Use `gh issue view` to get the issue content:
+
+```bash
+gh issue view {issue-number} --json title,body,labels
+```
+
+### 3. Get Commit History
+
+Get all commits on this branch that are not in the base branch (main):
+
+```bash
+git log main..HEAD --oneline
+git log main..HEAD --pretty=format:"%s%n%b"
+```
+
+### 4. Analyze and Generate PR Description
+
+Based on the issue and commits, generate a PR description following this template:
+
+```markdown
+# Description
+
+Closes #{issue-number}
+
+## PR Type
+
+What kind of change does this PR introduce?
+
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Documentation content changes
+- [ ] Tests
+- [ ] Other
+
+{Check the appropriate type based on issue labels and commit messages}
+
+## What's new?
+
+{Summarize the changes based on:
+1. The issue description and requirements
+2. The actual commits made on this branch
+Write 2-5 bullet points describing the key changes}
+
+## Implementation Details
+
+{If there are significant technical details worth mentioning:
+- Architecture decisions
+- Key files changed
+- Notable implementation choices}
+
+## Screenshots
+
+{If UI changes, mention "Add screenshots here" otherwise "N/A"}
+
+## Testing
+
+{Describe how this was tested:
+- [ ] Unit tests added/updated
+- [ ] Manual testing performed
+- [ ] Build passes}
+```
+
+### 5. Output
+
+Write the output to `.ai/outputs/git.md` file (overwrite if exists).
+
+Format:
+
+```markdown
+# PR Output
+
+**Generated:** {timestamp}
+**Issue:** #{issue-number}
+
+## Title
+
+{issue title - typically in format "type(scope): description"}
+
+## Description
+
+{the generated markdown description - note: remove the top-level "# Description" heading from the template since we use "## Description" here}
+```
+
+After writing the file, display a brief summary to the user:
+
+```text
+Wrote PR description to .ai/outputs/git.md
+
+- Issue: #{issue-number} {title}
+- Commits: {number of commits}
+- Type: {detected PR type}
+```
+
+## Notes
+
+- If branch name doesn't contain an issue number, ask the user for it
+- Determine PR type from:
+  - Issue labels (enhancement = Feature, bug = Bugfix)
+  - Branch name prefix (feat = Feature, fix = Bugfix, refactor = Refactoring)
+  - Commit messages
+- Keep the description concise but informative
+- Focus on the "what" and "why", not the "how" (code details are in the diff)
+- **IMPORTANT**: Use only ASCII characters in the output. Avoid Unicode symbols (arrows, special characters) as they may get corrupted. Use ASCII alternatives like `->`, `|`, `v` instead of `->`, `|`, `v`, etc.

--- a/.claude/commands/impl-verify.md
+++ b/.claude/commands/impl-verify.md
@@ -1,0 +1,254 @@
+# Impl Verify
+
+Verify the current implementation against the plan. Check if the actual code matches what was planned.
+
+## Input
+
+$ARGUMENTS
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `{plan-file}` | Plan file path (optional, auto-detected if not specified) |
+| `--ja` or `--jp` | Output in Japanese |
+
+**Default language:** English
+
+## Instructions
+
+### 1. Check Staged Files
+
+First, identify what files are staged for commit:
+
+```bash
+# Get list of staged files
+git diff --cached --name-only
+
+# Get staged changes summary
+git diff --cached --stat
+```
+
+If no staged files, report and exit:
+> No staged files found. Please stage your changes first with `git add`.
+
+### 2. Auto-detect Matching Plan File
+
+Find the plan that matches the staged changes:
+
+1. **List all plan files:**
+   ```bash
+   ls -t {PROJECT_ROOT}/.ai/outputs/plans/*.md
+   ```
+
+2. **Read each plan file** and extract:
+   - Target files mentioned in the plan
+   - Implementation steps and descriptions
+   - Component/module names
+
+3. **Compare against staged files:**
+   - Match file paths in plan vs staged files
+   - Match component/module names
+   - Calculate match score
+
+4. **Select the best match** and confirm with user:
+   ```
+   Detected plan file: {plan-file-path}
+   Match confidence: {high/medium/low}
+
+   Is this correct? (y/n)
+   ```
+
+If no match or user says no, list available plans and ask to select.
+
+### 3. Read the Plan
+
+Read the selected plan file and extract:
+
+- Implementation steps
+- Expected changes per file
+- Design decisions and approach
+- Acceptance criteria (if any)
+
+### 4. Read Actual Implementation
+
+For each file mentioned in the plan that is also staged:
+
+1. **Read the current file content** (not just the diff):
+   - Use the Read tool to read the actual file
+   - Understand the full implementation context
+
+2. **Read the staged changes**:
+   ```bash
+   git diff --cached -- {file_path}
+   ```
+
+3. **Analyze the implementation**:
+   - Does the code structure match the plan?
+   - Are the planned functions/types implemented?
+   - Does the approach match what was planned?
+
+### 5. Compare Plan vs Actual Implementation
+
+For each planned item, verify:
+
+| Check | Description |
+|-------|-------------|
+| File exists | Was the planned file created/modified? |
+| Structure | Does code structure match the plan? |
+| Approach | Is the implementation approach as planned? |
+| Completeness | Are all planned items implemented? |
+| Extras | Any unplanned additions? |
+
+### 6. Report: Plan vs Implementation
+
+#### English (Default)
+
+```markdown
+## Plan vs Implementation Report
+
+### Detected Plan
+
+**File:** {plan file path}
+**Match confidence:** {high/medium/low}
+
+### Staged Files
+
+{list of staged files}
+
+### Verification Results
+
+#### Matches Plan
+
+{Items where implementation matches the plan exactly}
+
+- {file}: {what matches}
+
+#### Deviations
+
+| Planned | Actual Implementation | Assessment |
+|---------|----------------------|------------|
+| {what was planned} | {what was actually implemented} | {OK/Needs Review/Issue} |
+
+#### Missing from Plan
+
+{Items that were staged but not mentioned in the plan}
+
+- {file}: {what was added}
+
+#### Not Yet Implemented
+
+{Items in the plan that are not in staged changes}
+
+- {planned item}: {status}
+
+### Code Review Notes
+
+{Any observations about the implementation quality, potential issues, or suggestions}
+
+### Summary
+
+{Overall assessment: Does the implementation match the plan?}
+
+- Plan adherence: {percentage or qualitative}
+- Recommendation: {proceed with commit / review needed / revise implementation}
+```
+
+#### Japanese (--ja / --jp)
+
+```markdown
+## 計画と実装の検証レポート
+
+### 検出された計画
+
+**ファイル:** {plan file path}
+**マッチ度:** {高/中/低}
+
+### ステージングされたファイル
+
+{ステージングされたファイル一覧}
+
+### 検証結果
+
+#### 計画通り
+
+{計画通りに実装された項目}
+
+- {file}: {一致している内容}
+
+#### 乖離
+
+| 計画 | 実際の実装 | 評価 |
+|------|-----------|------|
+| {計画された内容} | {実際の実装内容} | {OK/要確認/問題あり} |
+
+#### 計画外の追加
+
+{計画になかったがステージングされた項目}
+
+- {file}: {追加された内容}
+
+#### 未実装
+
+{計画にあるがステージングされていない項目}
+
+- {計画項目}: {状況}
+
+### コードレビューノート
+
+{実装品質、潜在的な問題、提案などの所見}
+
+### まとめ
+
+{全体評価：実装は計画と一致しているか？}
+
+- 計画準拠度: {パーセンテージまたは定性評価}
+- 推奨: {コミット可 / 要レビュー / 実装修正}
+```
+
+### 7. Offer Next Actions
+
+#### English (Default)
+
+```markdown
+### Next Actions
+
+1. **Proceed to commit** - Implementation matches plan, ready to commit
+2. **Review specific files** - Look at specific deviations in detail
+3. **Update plan** - Sync plan with actual implementation
+4. **Revise implementation** - Adjust code to match plan
+5. **Done** - Review complete
+```
+
+#### Japanese (--ja / --jp)
+
+```markdown
+### 次のアクション
+
+1. **コミットへ進む** - 実装が計画と一致、コミット可能
+2. **特定ファイルを確認** - 乖離箇所を詳細に確認
+3. **計画を更新** - 計画を実装に合わせて更新
+4. **実装を修正** - 計画に合わせてコードを修正
+5. **完了** - レビュー終了
+```
+
+## Examples
+
+```bash
+# Verify staged changes against auto-detected plan (English)
+/impl-verify
+
+# Verify in Japanese
+/impl-verify --ja
+
+# Specify plan file directly
+/impl-verify .ai/outputs/plans/cognet-interaction.md
+```
+
+## Notes
+
+- This command reads **actual file contents**, not just diffs
+- Compares the real implementation against planned design
+- Helps catch design drift before committing
+- Run before `/git-commit` to ensure plan adherence
+- If no staged files, prompts to stage changes first

--- a/.claude/rules/ai-output.md
+++ b/.claude/rules/ai-output.md
@@ -1,0 +1,73 @@
+# AI Output Rules
+
+## Output Directory
+
+All agent outputs are written under the **project root's** `.ai/outputs/` directory.
+
+**IMPORTANT:** Always use the absolute path from the Geolis project root, NOT the current working directory.
+
+Where `PROJECT_ROOT` is the directory containing `Cargo.toml`.
+
+## Directory Structure
+
+```
+{PROJECT_ROOT}/.ai/outputs/
+├── git.md                        # Git commit / PR output (overwritten each time)
+├── plans/                        # Implementation plans (auto-named)
+│   └── {plan-name}.md
+└── summaries/                    # Task summaries
+    └── summary-{task-name}.md
+```
+
+## File Paths by Command
+
+| Command | Output Path |
+|---------|-------------|
+| `/git-commit` | `.ai/outputs/git.md` |
+| `/git-pr` | `.ai/outputs/git.md` |
+| Implementation plans | `.ai/outputs/plans/{name}.md` |
+| Task summaries | `.ai/outputs/summaries/summary-{name}.md` |
+
+**CRITICAL:** `/git-commit` and `/git-pr` write to `.ai/outputs/git.md`, NOT to `summaries/`.
+
+## When to Write Output
+
+Write to AI_OUTPUTS directory when:
+
+- Generating commit messages (`/git-commit`)
+- Creating PR descriptions (`/git-pr`)
+- Creating implementation plans (`/plan-issue`, `/plan-refactor`)
+- Completing significant multi-step tasks
+- User explicitly requests a summary
+
+## When NOT to Write Output
+
+Skip writing output for:
+
+- Simple single-step tasks
+- Direct answers to questions
+- Code edits without planning phase
+- Conversational responses
+
+## Output Format
+
+Each file should include:
+
+```markdown
+# {Title}
+
+**Generated:** {timestamp}
+**Task:** {brief description}
+
+## Content
+
+{the generated content}
+
+## Context
+
+{optional: files modified, commands run, etc.}
+```
+
+## Cleanup
+
+Old output files can be deleted periodically. These are temporary working files, not permanent documentation.

--- a/.claude/rules/build.md
+++ b/.claude/rules/build.md
@@ -1,0 +1,71 @@
+# Build Verification Rules
+
+## Workspace Build Commands
+
+This project is a Cargo workspace with multiple crates and examples. Use the appropriate commands to verify builds.
+
+### Quick Check (Recommended)
+
+```bash
+# Check all targets without building (fastest)
+cargo check --workspace --all-targets
+```
+
+### Full Build Verification
+
+```bash
+# Build all crates and examples
+cargo build --workspace --all-targets
+```
+
+### Lint Check
+
+```bash
+# Clippy on all targets (catches more issues)
+cargo clippy --workspace --all-targets
+```
+
+### With All Features (Comprehensive)
+
+```bash
+# Check with all features enabled
+cargo check --workspace --all-targets --all-features
+
+# Build with all features enabled
+cargo build --workspace --all-targets --all-features
+
+# Clippy with all features enabled
+cargo clippy --workspace --all-targets --all-features
+```
+
+## What `--all-targets` Includes
+
+- `--lib` - Library crates
+- `--bins` - Binary crates
+- `--examples` - Example programs
+- `--tests` - Test code
+- `--benches` - Benchmarks
+
+## What `--all-features` Includes
+
+Enables all optional features across the workspace. Features will be updated as the project develops and new crates are added.
+
+## When to Use Each Command
+
+| Situation | Command |
+|-----------|---------|
+| Quick syntax check | `cargo check --workspace --all-targets` |
+| Verify full build | `cargo build --workspace --all-targets` |
+| Before commit | `cargo clippy --workspace --all-targets` |
+| Comprehensive check | `cargo check --workspace --all-targets --all-features` |
+| PR/CI verification | `cargo clippy --workspace --all-targets --all-features` |
+| Single example | `cargo build --example <name>` |
+| Run tests | `cargo test --workspace` |
+| Run tests (all features) | `cargo test --workspace --all-features` |
+
+## Common Mistakes to Avoid
+
+- `cargo build` alone only builds the root package
+- `cargo build --workspace` misses examples and tests
+- Always use `--all-targets` for complete verification
+- Without `--all-features`, feature-gated code is not checked

--- a/.claude/rules/debug.md
+++ b/.claude/rules/debug.md
@@ -1,0 +1,336 @@
+# Debug Viewer
+
+## Overview
+
+`examples/debug/` is a debug viewer for visualising Geolis meshes.
+
+## Development Workflow
+
+The debug viewer is the core tool for a **visual TDD** workflow. Follow these 3 steps.
+
+### Step 1: Build ground truth with `--test`
+
+Hardcode hand-computed correct geometry from documentation or manual calculation, then visualize with `--test` mode to verify.
+
+```bash
+# Visualize ground truth
+cargo run --example debug -- --test offset_intersection
+```
+
+- Hardcode hand-computed vertex coordinates in `test/`
+- Visually confirm correctness in the viewer
+- Color convention: Gray = original shape, Green = expected inward, Blue = expected outward
+- **Label every case** with a sequential number using `register_label` (see [Case Labels](#case-labels))
+
+### Step 2: Create test cases and algorithm output pattern from ground truth
+
+From the verified ground truth, create **three things**:
+
+1. **`#[test]` cases** — automated tests comparing algorithm output against expected values
+2. **`patterns/` cases** — the same input shapes rendered through the actual algorithm for visual comparison
+
+This ensures every ground truth case is testable (`cargo test`) and visually comparable (`cargo run --example debug`).
+
+```rust
+// 1. Unit test (in src/ or integration tests)
+#[test]
+fn test_t_shape_inward_offset() {
+    let result = PolylineOffset2D::new(t_shape(), 0.3, true).execute().unwrap();
+    // Compare against ground truth coordinates from Step 1
+    assert_approx_eq(&result, &expected_inward);
+}
+```
+
+```rust
+// 2. Algorithm output pattern (in patterns/*.rs)
+// Uses the SAME input shapes as test/, but runs them through the algorithm
+pub fn register(storage: &MeshStorage) {
+    let points = t_shape_points();
+    register_stroke(storage, &points, style, true, GRAY);
+
+    let result = PolylineOffset2D::new(points, 0.3, true).execute().unwrap();
+    register_stroke(storage, &result, style, true, GREEN);
+}
+```
+
+- **Case numbering must match** between `test/` and `patterns/` for the same pattern name
+- Verify algorithm correctness automatically with `cargo test`
+- Iterate on the algorithm until all tests pass
+
+> **ABSOLUTE RULE: Never modify ground truth to match the algorithm.**
+>
+> Ground truth data (Step 1) and test expected values (Step 2) are the **specification**.
+> When tests fail, the algorithm is wrong — not the test data.
+>
+> - **NEVER** change hardcoded expected coordinates in `test/` or `#[test]` to make tests pass
+> - **NEVER** relax tolerance values to paper over algorithm inaccuracy
+> - **ALWAYS** fix the algorithm in `src/` to produce the correct output
+>
+> The only acceptable reason to change ground truth is if the original hand calculation was wrong,
+> confirmed by re-deriving from first principles. In that case, update both the `test/` visualization
+> and the `#[test]` expected values together, with a clear explanation of the calculation error.
+
+### Step 3: Visualize algorithm output in default mode
+
+Once tests pass, run the viewer without `--test` to visualize the actual algorithm output and confirm overall appearance.
+
+```bash
+# Visualize actual algorithm output
+cargo run --example debug -- offset_intersection
+```
+
+- Code in `patterns/` calls the algorithm and renders results
+- Visually confirm that algorithm output matches expected results for the same input shapes
+- Catch edge cases and subtle numerical precision issues here
+
+### Workflow Summary
+
+```
+ +----------------------------------------------------------+
+ | Step 1: Visualize ground truth with --test                |
+ |   Hardcode in test/ -> visual confirmation in viewer      |
+ +----------------------------+-----------------------------+
+                              |
+                              v
+ +----------------------------------------------------------+
+ | Step 2: Ground truth -> #[test] -> iterate on algorithm   |
+ |   Loop with cargo test                                    |
+ +----------------------------+-----------------------------+
+                              |
+                              v
+ +----------------------------------------------------------+
+ | Step 3: Visualize algorithm output in default mode        |
+ |   Render actual output in patterns/ -> final visual check |
+ +----------------------------------------------------------+
+```
+
+## File Structure
+
+```
+examples/debug/
++-- main.rs              -- Entry point (DO NOT EDIT)
++-- viewer.rs            -- Pure viewer UI (DO NOT EDIT)
++-- test_meshes.rs       -- CLI dispatcher (DO NOT EDIT)
++-- patterns/            -- Algorithm output visualization (Step 3)
+|   +-- mod.rs           -- Pattern registry + shared utilities (selectively editable)
+|   +-- stroke_joins.rs  -- LineJoin comparison pattern
+|   +-- basic_strokes.rs -- Basic stroke shapes pattern
++-- test/                -- Ground truth visualization (Step 1)
+    +-- mod.rs           -- Test pattern registry (selectively editable)
+    +-- *.rs             -- Ground truth pattern files
+```
+
+| File | Role | Editable? |
+|------|------|-----------|
+| `main.rs` | Logging init, app startup | No |
+| `viewer.rs` | `AppState`, viewport layout, components | No |
+| `test_meshes.rs` | CLI arg -> pattern dispatch | No |
+| `patterns/mod.rs` | Pattern registry + shared conversion utilities | Add new patterns here |
+| `patterns/*.rs` | Algorithm output patterns | **Yes** |
+| `test/mod.rs` | Test pattern registry + re-exports | Add new test patterns here |
+| `test/*.rs` | Ground truth patterns | **Yes** |
+
+## How It Works
+
+1. `test_meshes.rs` parses CLI arguments (`--test` flag + pattern name)
+2. Without `--test`: `patterns::register(storage, name)` dispatches to algorithm output
+3. With `--test`: `test::register(storage, name)` dispatches to ground truth data
+4. Each pattern file calls shared utilities to register meshes into `MeshStorage`
+5. The viewer displays them in 2D (left) and 3D (right) viewports
+
+## Pattern System
+
+### Running Patterns
+
+```bash
+# Default (stroke_joins)
+cargo run --example debug
+
+# Algorithm output pattern (Step 3)
+cargo run --example debug -- stroke_joins
+cargo run --example debug -- offset_intersection
+
+# Ground truth (Step 1)
+cargo run --example debug -- --test offset_intersection
+
+# Unknown pattern -> prints available list, falls back to stroke_joins
+cargo run --example debug -- foo
+```
+
+### Available Patterns
+
+| Pattern | Mode | Description |
+|---------|------|-------------|
+| `stroke_joins` | default | `LineJoin` comparison -- Miter / Auto / Bevel columns |
+| `basic_strokes` | default | Simple stroke shapes (line, L-shape, triangle, curve, square) |
+| `polyline_offset` | default | Polyline offset algorithm results |
+| `offset_intersection` | default | Offset self-intersection algorithm results |
+| `offset_intersection` | `--test` | Hand-computed ground truth for offset self-intersection |
+
+### Case Labels
+
+Every pattern that renders multiple test cases **must** label each case with a sequential number using `register_label`. This makes it easy to reference specific cases in conversation (e.g. "case 5 is wrong").
+
+#### Rules
+
+1. **Number every case sequentially** starting from 1, across the entire pattern file
+2. **Use the same numbering** in both `patterns/` (algorithm output) and `test/` (ground truth) for the same pattern
+3. **Position labels above-left** of each shape group — typically `(bx - 2, by + shape_height + 0.5)` or a consistent offset that doesn't overlap with the shape
+4. **Use yellow color** `Color::rgb(255, 220, 80)` for labels — distinct from Gray/Green/Blue shape colors
+5. **Label size** ~1.0–1.5 world units (adjust to shape scale)
+6. **Define constants** at the top of the pattern file:
+
+```rust
+const LABEL_SIZE: f64 = 1.2;
+const LABEL_COLOR: Color = Color::rgb(255, 220, 80);
+```
+
+#### Example
+
+```rust
+use super::{register_label, register_stroke};
+
+const LABEL_SIZE: f64 = 1.2;
+const LABEL_COLOR: Color = Color::rgb(255, 220, 80);
+
+pub fn register(storage: &MeshStorage) {
+    // Case 1
+    register_label(storage, -14.0, 12.5, "1", LABEL_SIZE, LABEL_COLOR);
+    register_shape(storage, -12.0, 6.0, /* ... */);
+
+    // Case 2
+    register_label(storage, 0.0, 12.5, "2", LABEL_SIZE, LABEL_COLOR);
+    register_shape(storage, 2.0, 6.0, /* ... */);
+}
+```
+
+#### `register_label` API
+
+```rust
+register_label(storage, x, y, text, size, color)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `storage` | `&MeshStorage` to register meshes into |
+| `x`, `y` | World-space position (bottom-left of first digit) |
+| `text` | Digits `0`–`9` only (rendered as 7-segment display) |
+| `size` | Height of each digit in world units |
+| `color` | Label color |
+
+Defined in `patterns/mod.rs`, re-exported in `test/mod.rs`.
+
+### Adding a New Pattern
+
+1. Create `examples/debug/patterns/new_pattern.rs`:
+
+```rust
+use revion_ui::MeshStorage;
+
+use super::{register_label, register_stroke}; // always import register_label
+
+const LABEL_SIZE: f64 = 1.2;
+const LABEL_COLOR: Color = Color::rgb(255, 220, 80);
+
+pub fn register(storage: &MeshStorage) {
+    // Case 1
+    register_label(storage, -14.0, 12.5, "1", LABEL_SIZE, LABEL_COLOR);
+    // Register meshes here
+}
+```
+
+2. Update `examples/debug/patterns/mod.rs`:
+
+```rust
+// Add module declaration
+pub mod new_pattern;
+
+// Add to PATTERNS list
+pub const PATTERNS: &[&str] = &["stroke_joins", "basic_strokes", "new_pattern"];
+
+// Add match arm in register()
+pub fn register(storage: &MeshStorage, name: &str) -> bool {
+    match name {
+        // ...existing...
+        "new_pattern" => { new_pattern::register(storage); true }
+        _ => false,
+    }
+}
+```
+
+### Adding a New Test (Ground Truth) Pattern
+
+1. Create `examples/debug/test/new_pattern.rs`:
+
+```rust
+use revion_ui::MeshStorage;
+
+use super::{register_label, register_stroke}; // re-exported from patterns
+
+const LABEL_SIZE: f64 = 1.2;
+const LABEL_COLOR: Color = Color::rgb(255, 220, 80);
+
+pub fn register(storage: &MeshStorage) {
+    // Case 1 — use same numbering as the corresponding patterns/ file
+    register_label(storage, -14.0, 12.5, "1", LABEL_SIZE, LABEL_COLOR);
+    // Register hardcoded expected meshes here
+}
+```
+
+2. Update `examples/debug/test/mod.rs`:
+
+```rust
+pub mod new_pattern;
+
+pub const PATTERNS: &[&str] = &["offset_intersection", "new_pattern"];
+
+pub fn register(storage: &MeshStorage, name: &str) -> bool {
+    match name {
+        // ...existing...
+        "new_pattern" => { new_pattern::register(storage); true }
+        _ => false,
+    }
+}
+```
+
+### Shared Utilities (in `patterns/mod.rs`)
+
+| Function | Description |
+|----------|-------------|
+| `into_raw_mesh_2d(mesh, color)` | Convert Geolis `TriangleMesh` -> Revion `RawMesh2D` (XY projection) |
+| `into_raw_mesh_3d(mesh, color)` | Convert Geolis `TriangleMesh` -> Revion `RawMesh3D` |
+| `register_stroke(storage, points, style, closed, color)` | Tessellate + register both 2D and 3D |
+| `register_label(storage, x, y, text, size, color)` | Render digit string as 7-segment mesh (2D + 3D) |
+
+Test patterns access these via re-export in `test/mod.rs`.
+
+## Running
+
+```bash
+# Default pattern
+cargo run --example debug
+
+# Specific pattern
+cargo run --example debug -- basic_strokes
+
+# Ground truth
+cargo run --example debug -- --test offset_intersection
+
+# With Revion renderer debug logs
+RUST_LOG=revion_renderer=debug cargo run --example debug -- stroke_joins
+
+# Verbose -- all crates
+RUST_LOG=debug cargo run --example debug
+```
+
+## Logging
+
+The viewer uses `tracing` with `EnvFilter`. Defaults:
+
+| Target | Level |
+|--------|-------|
+| `geolis` | INFO |
+| `debug` | INFO |
+| Everything else (revion, wgpu, ...) | WARN |
+
+Override via `RUST_LOG` environment variable.

--- a/.claude/rules/rust-coding.md
+++ b/.claude/rules/rust-coding.md
@@ -1,0 +1,362 @@
+# Rust Coding Rules
+
+## Error Handling
+
+### Never Use `unwrap()` or `expect()` in Production Code
+
+| Allowed | Forbidden |
+|---------|-----------|
+| Tests (`#[cfg(test)]`) | Library code |
+| Examples | Application code |
+| Prototyping (temporary) | Any committed code |
+
+```rust
+// Bad
+let value = some_option.unwrap();
+let result = some_result.expect("should work");
+
+// Good
+let value = some_option.ok_or(MyError::NotFound)?;
+let result = some_result?;
+```
+
+### Use the `?` Operator
+
+Propagate errors with `?` instead of manual matching:
+
+```rust
+// Bad
+fn read_config() -> Result<Config, MyError> {
+    let content = match std::fs::read_to_string("config.toml") {
+        Ok(c) => c,
+        Err(e) => return Err(MyError::Io(e)),
+    };
+    // ...
+}
+
+// Good
+fn read_config() -> Result<Config, MyError> {
+    let content = std::fs::read_to_string("config.toml")?;
+    // ...
+}
+```
+
+### Custom Error Types with `thiserror`
+
+Define domain-specific errors using `thiserror`:
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum MyError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Parse error at line {line}: {message}")]
+    Parse { line: usize, message: String },
+
+    #[error("Not found: {0}")]
+    NotFound(String),
+}
+```
+
+### Error Handling Patterns
+
+| Pattern | Use Case |
+|---------|----------|
+| `?` operator | Propagate error to caller |
+| `.ok_or(err)?` | Convert Option to Result |
+| `.map_err()?` | Transform error type |
+| `if let Err(e) = ...` | Handle error locally |
+| `.unwrap_or(default)` | Provide fallback value |
+| `.unwrap_or_else(\|\| ...)` | Lazy fallback computation |
+
+## Safety
+
+### Minimize `unsafe` Usage
+
+- Avoid `unsafe` unless absolutely necessary
+- When required, isolate in small, well-documented functions
+- Add `// SAFETY:` comments explaining invariants
+
+```rust
+// SAFETY: We verified that ptr is valid and aligned
+// in the constructor, and the lifetime is bounded by 'a.
+unsafe { &*self.ptr }
+```
+
+### Prefer Safe Abstractions
+
+| Unsafe | Safe Alternative |
+|--------|------------------|
+| Raw pointers | References, `Box`, `Rc`, `Arc` |
+| `transmute` | `From`/`Into` traits |
+| Manual memory | RAII patterns |
+
+## Performance
+
+### Ownership and Borrowing
+
+```rust
+// Bad - unnecessary clone
+fn process(data: Vec<u8>) {
+    let copy = data.clone();
+    // ...
+}
+
+// Good - borrow when you don't need ownership
+fn process(data: &[u8]) {
+    // ...
+}
+
+// Good - take ownership only when needed
+fn consume(data: Vec<u8>) -> ProcessedData {
+    // data is moved and consumed
+}
+```
+
+### Smart Pointer Guidelines
+
+| Type | Use Case |
+|------|----------|
+| `Box<T>` | Heap allocation, trait objects |
+| `Rc<T>` | Single-threaded shared ownership |
+| `Arc<T>` | Multi-threaded shared ownership |
+| `Cow<'a, T>` | Clone-on-write optimization |
+
+### Iterator Preference
+
+```rust
+// Bad - manual indexing
+for i in 0..vec.len() {
+    process(&vec[i]);
+}
+
+// Good - iterator
+for item in &vec {
+    process(item);
+}
+
+// Good - iterator with transformation
+let results: Vec<_> = items.iter().map(transform).collect();
+```
+
+### Avoid Unnecessary Allocations
+
+```rust
+// Bad - allocates intermediate String
+let s = format!("{}", value);
+log::info!("{}", s);
+
+// Good - format directly
+log::info!("{}", value);
+
+// Bad - creates new Vec
+let filtered = vec.iter().filter(|x| x > &0).cloned().collect::<Vec<_>>();
+for item in filtered { ... }
+
+// Good - lazy iteration
+for item in vec.iter().filter(|x| **x > 0) { ... }
+```
+
+## Code Style
+
+### Naming Conventions
+
+| Item | Convention | Example |
+|------|------------|---------|
+| Types | PascalCase | `MyStruct`, `ErrorKind` |
+| Functions | snake_case | `get_value`, `process_data` |
+| Constants | SCREAMING_SNAKE_CASE | `MAX_SIZE`, `DEFAULT_TIMEOUT` |
+| Modules | snake_case | `my_module` |
+| Type parameters | Single uppercase | `T`, `E`, `K`, `V` |
+| Lifetimes | Short lowercase | `'a`, `'b`, `'ctx` |
+
+### Documentation
+
+Document public APIs with `///`:
+
+```rust
+/// Processes the input data and returns the result.
+///
+/// # Arguments
+///
+/// * `input` - The raw input data to process
+///
+/// # Returns
+///
+/// The processed output, or an error if processing fails.
+///
+/// # Examples
+///
+/// ```
+/// let result = process_data(&input)?;
+/// ```
+pub fn process_data(input: &[u8]) -> Result<Output, MyError> {
+    // ...
+}
+```
+
+### Visibility
+
+Minimize public surface area:
+
+```rust
+// Prefer private by default
+struct InternalState { ... }
+
+// Only expose what's needed
+pub struct PublicApi {
+    state: InternalState,  // private field
+}
+
+// Use pub(crate) for internal sharing
+pub(crate) fn internal_helper() { ... }
+```
+
+## Patterns
+
+### Builder Pattern
+
+For types with many optional fields:
+
+```rust
+pub struct Config {
+    timeout: Duration,
+    retries: u32,
+    // ...
+}
+
+impl Config {
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::default()
+    }
+}
+
+#[derive(Default)]
+pub struct ConfigBuilder {
+    timeout: Option<Duration>,
+    retries: Option<u32>,
+}
+
+impl ConfigBuilder {
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    pub fn retries(mut self, retries: u32) -> Self {
+        self.retries = Some(retries);
+        self
+    }
+
+    pub fn build(self) -> Result<Config, ConfigError> {
+        Ok(Config {
+            timeout: self.timeout.unwrap_or(Duration::from_secs(30)),
+            retries: self.retries.unwrap_or(3),
+        })
+    }
+}
+```
+
+### Newtype Pattern
+
+Wrap primitives for type safety:
+
+```rust
+// Bad - easy to confuse
+fn process(user_id: u64, order_id: u64) { ... }
+
+// Good - distinct types
+pub struct UserId(pub u64);
+pub struct OrderId(pub u64);
+
+fn process(user_id: UserId, order_id: OrderId) { ... }
+```
+
+### Type State Pattern
+
+Encode state in the type system:
+
+```rust
+pub struct Connection<S> {
+    inner: TcpStream,
+    _state: PhantomData<S>,
+}
+
+pub struct Disconnected;
+pub struct Connected;
+pub struct Authenticated;
+
+impl Connection<Disconnected> {
+    pub fn connect(addr: &str) -> Result<Connection<Connected>, Error> { ... }
+}
+
+impl Connection<Connected> {
+    pub fn authenticate(self, creds: &Credentials) -> Result<Connection<Authenticated>, Error> { ... }
+}
+
+impl Connection<Authenticated> {
+    pub fn send(&mut self, data: &[u8]) -> Result<(), Error> { ... }
+}
+```
+
+## Common Derive Traits
+
+Implement standard traits appropriately:
+
+| Trait | When to Derive |
+|-------|----------------|
+| `Debug` | Almost always (except sensitive data) |
+| `Clone` | When copying makes sense |
+| `Copy` | Small, trivially copyable types |
+| `PartialEq`, `Eq` | For comparison/testing |
+| `Hash` | For use in HashMap/HashSet |
+| `Default` | When a sensible default exists |
+| `Send`, `Sync` | Usually automatic; verify for custom types |
+
+## Clippy Enforcement
+
+The following Clippy lints are enforced:
+
+```rust
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+```
+
+## Testing
+
+### Test Organization
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_happy_path() {
+        let result = process(&valid_input);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_error_case() {
+        let result = process(&invalid_input);
+        assert!(matches!(result, Err(MyError::InvalidInput(_))));
+    }
+}
+```
+
+### In Tests, `unwrap()` is Acceptable
+
+```rust
+#[test]
+fn test_parsing() {
+    // OK in tests - failure will show in test output
+    let config = Config::from_str(INPUT).unwrap();
+    assert_eq!(config.name, "test");
+}
+```

--- a/.claude/rules/test-data.md
+++ b/.claude/rules/test-data.md
@@ -1,0 +1,88 @@
+# Test Data Generation Rules
+
+## Token Limit Awareness
+
+Claude Code has a 64000 output token limit. Geometric test data (hardcoded coordinates)
+is extremely token-heavy. Follow these rules to avoid exceeding the limit.
+
+## Rules
+
+### 1. Never Write Large Files in One Shot
+
+- Do NOT use the Write tool to create files with >200 lines of test data
+- Instead: Write a skeleton first (imports, module structure, helpers), then use Edit
+  to add test functions one at a time
+- When modifying existing test files, always use Edit (not Write) to change only the
+  relevant section
+
+### 2. Extract Shared Shape Definitions
+
+Define reusable shape constructors instead of duplicating coordinate arrays:
+
+```rust
+// GOOD: Define once, reuse everywhere
+fn t_shape_points() -> Vec<Point3> {
+    vec![
+        Point3::new(0.0, 0.0, 0.0),
+        Point3::new(10.0, 0.0, 0.0),
+        // ...
+    ]
+}
+
+#[test]
+fn t_shape_inward_d03() {
+    let result = PolylineOffset2D::new(t_shape_points(), 0.3, true).execute().unwrap();
+    // ...
+}
+
+// BAD: Duplicating the same coordinates in every test
+#[test]
+fn t_shape_inward_d03() {
+    let points = vec![Point3::new(0.0, 0.0, 0.0), Point3::new(10.0, 0.0, 0.0), ...];
+    // ...
+}
+```
+
+### 3. Parameterize Expected Values When Possible
+
+When the expected result follows a formula, use a helper function:
+
+```rust
+// GOOD: Parameterized expected values
+fn open_cross_expected(d: f64) -> Vec<Point3> {
+    vec![
+        Point3::new(-1.5, -d, 0.0),
+        Point3::new(-1.5, d, 0.0),
+        // ...
+    ]
+}
+
+// BAD: Separate hardcoded arrays for each distance
+```
+
+### 4. Add Tests Incrementally
+
+When creating multiple test functions:
+1. First Edit: Add helper functions (shape constructors, assertion utilities)
+2. Subsequent Edits: Add one or two `#[test]` functions per Edit call
+3. Never try to add more than ~5 test functions in a single response
+
+### 5. Keep Test Files Under 500 Lines
+
+If a test module grows beyond ~500 lines, split into sub-modules:
+
+```rust
+#[cfg(test)]
+mod tests {
+    mod t_shape_tests;
+    mod cross_tests;
+    mod open_polyline_tests;
+}
+```
+
+### 6. Debug Viewer Patterns
+
+For `examples/debug/patterns/` and `examples/debug/test/`:
+- Each pattern file should stay under 200 lines
+- Reuse `register_stroke` and other shared utilities from `patterns/mod.rs`
+- Group related shapes into a single pattern file rather than creating one file per shape

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 .DS_Store
+.ai/instructions.md
+.ai/outputs/git.md
+.ai/outputs/*

--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -15,6 +15,43 @@ pub enum SlotId {
     Output(OutputSlotId),
 }
 
+/// A 3D vector value for passing spatial data through the graph.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Vector3 {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+impl Vector3 {
+    pub fn new(x: f64, y: f64, z: f64) -> Self {
+        Self { x, y, z }
+    }
+
+    pub fn zero() -> Self {
+        Self {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        }
+    }
+}
+
+/// An RGBA color value for passing color data through the graph.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ColorValue {
+    pub r: f64,
+    pub g: f64,
+    pub b: f64,
+    pub a: f64,
+}
+
+impl ColorValue {
+    pub fn new(r: f64, g: f64, b: f64, a: f64) -> Self {
+        Self { r, g, b, a }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub enum DataType {
     #[default]
@@ -23,6 +60,10 @@ pub enum DataType {
     /// Mesh data type for geometry outputs.
     /// Stores arbitrary mesh data as `Arc<dyn Any>` via `Data::from_mesh()`.
     Mesh,
+    /// 3D vector (x, y, z).
+    Vector3,
+    /// RGBA color value.
+    Color,
 }
 
 impl DataType {
@@ -32,6 +73,8 @@ impl DataType {
             DataType::String => TypeId::of::<String>(),
             // Mesh holds arbitrary types; type_id is not used for Mesh (see Data::value())
             DataType::Mesh => TypeId::of::<()>(),
+            DataType::Vector3 => TypeId::of::<Vector3>(),
+            DataType::Color => TypeId::of::<ColorValue>(),
         }
     }
 
@@ -40,6 +83,8 @@ impl DataType {
             DataType::Number => type_name::<f64>(),
             DataType::String => type_name::<String>(),
             DataType::Mesh => "Mesh",
+            DataType::Vector3 => "Vector3",
+            DataType::Color => "Color",
         }
     }
 
@@ -53,6 +98,8 @@ impl DataType {
             DataType::String => value.downcast_ref::<String>().is_some(),
             // Mesh accepts any type
             DataType::Mesh => true,
+            DataType::Vector3 => value.downcast_ref::<Vector3>().is_some(),
+            DataType::Color => value.downcast_ref::<ColorValue>().is_some(),
         }
     }
 }
@@ -86,6 +133,12 @@ impl Serialize for Data {
             }
             DataType::Mesh => Err(serde::ser::Error::custom(
                 "Mesh data type is not serializable",
+            )),
+            DataType::Vector3 => Err(serde::ser::Error::custom(
+                "Vector3 data type is not serializable",
+            )),
+            DataType::Color => Err(serde::ser::Error::custom(
+                "Color data type is not serializable",
             )),
         }
     }
@@ -137,6 +190,8 @@ impl Data {
         let data_type = match type_id {
             t if t == TypeId::of::<f64>() => DataType::Number,
             t if t == TypeId::of::<String>() => DataType::String,
+            t if t == TypeId::of::<Vector3>() => DataType::Vector3,
+            t if t == TypeId::of::<ColorValue>() => DataType::Color,
             _ => return Err(format!("Invalid DataType: {}", type_name::<T>())),
         };
 
@@ -163,6 +218,8 @@ impl Data {
         let data_type = match type_id {
             t if t == TypeId::of::<f64>() => DataType::Number,
             t if t == TypeId::of::<String>() => DataType::String,
+            t if t == TypeId::of::<Vector3>() => DataType::Vector3,
+            t if t == TypeId::of::<ColorValue>() => DataType::Color,
             _ => return Err("Unsupported data type".to_string()),
         };
 

--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -81,9 +81,45 @@ pub enum DataType {
     Vertices,
     /// A boolean value.
     Bool,
+    /// BRep solid geometry.
+    /// Stores arbitrary BRep data as `Arc<dyn Any>` via `Data::from_brep()`.
+    BRep,
+    /// Application-defined domain type.
+    /// Connection validation uses name equality — only ports with the same
+    /// domain name can be connected.
+    Domain(&'static str),
 }
 
 impl DataType {
+    /// Human-readable label for this data type.
+    pub fn label(&self) -> &str {
+        match self {
+            DataType::Number => "Number",
+            DataType::String => "String",
+            DataType::Mesh => "Mesh",
+            DataType::Vector3 => "Vector3",
+            DataType::Color => "Color",
+            DataType::Vertices => "Vertices",
+            DataType::Bool => "Bool",
+            DataType::BRep => "BRep",
+            DataType::Domain(name) => name,
+        }
+    }
+
+    /// All standard (non-Domain) data types for UI dropdowns.
+    pub fn standard_types() -> &'static [DataType] {
+        &[
+            DataType::Number,
+            DataType::String,
+            DataType::Bool,
+            DataType::Vector3,
+            DataType::Color,
+            DataType::Mesh,
+            DataType::Vertices,
+            DataType::BRep,
+        ]
+    }
+
     fn type_id(&self) -> TypeId {
         match self {
             DataType::Number => TypeId::of::<f64>(),
@@ -94,6 +130,8 @@ impl DataType {
             DataType::Color => TypeId::of::<ColorValue>(),
             DataType::Vertices => TypeId::of::<Vertices>(),
             DataType::Bool => TypeId::of::<bool>(),
+            DataType::BRep => TypeId::of::<()>(),
+            DataType::Domain(_) => TypeId::of::<()>(),
         }
     }
 
@@ -106,6 +144,8 @@ impl DataType {
             DataType::Color => "Color",
             DataType::Vertices => "Vertices",
             DataType::Bool => "Bool",
+            DataType::BRep => "BRep",
+            DataType::Domain(name) => name,
         }
     }
 
@@ -117,8 +157,8 @@ impl DataType {
         match self {
             DataType::Number => value.downcast_ref::<f64>().is_some(),
             DataType::String => value.downcast_ref::<String>().is_some(),
-            // Mesh accepts any type
-            DataType::Mesh => true,
+            // Mesh, BRep, Domain accept any type (dynamic downcast)
+            DataType::Mesh | DataType::BRep | DataType::Domain(_) => true,
             DataType::Vector3 => value.downcast_ref::<Vector3>().is_some(),
             DataType::Color => value.downcast_ref::<ColorValue>().is_some(),
             DataType::Vertices => value.downcast_ref::<Vertices>().is_some(),
@@ -173,6 +213,13 @@ impl Serialize for Data {
                     .ok_or_else(|| serde::ser::Error::custom("Failed to downcast value to bool"))?;
                 serializer.serialize_bool(*value)
             }
+            DataType::BRep => Err(serde::ser::Error::custom(
+                "BRep data type is not serializable",
+            )),
+            DataType::Domain(name) => Err(serde::ser::Error::custom(format!(
+                "Domain type '{}' is not serializable",
+                name
+            ))),
         }
     }
 }
@@ -258,6 +305,27 @@ impl Data {
         }
     }
 
+    /// Create a BRep data value from any type.
+    ///
+    /// BRep data holds arbitrary BRep geometry types as `Arc<dyn Any>`.
+    pub fn from_brep<T: Any + Send + Sync + 'static>(value: T) -> Self {
+        Data {
+            value: Arc::new(value),
+            data_type: DataType::BRep,
+        }
+    }
+
+    /// Create a domain-typed data value.
+    ///
+    /// Domain types carry an application-defined name for type-safe connections.
+    /// Only ports with the same domain name can be connected.
+    pub fn from_domain<T: Any + Send + Sync + 'static>(value: T, name: &'static str) -> Self {
+        Data {
+            value: Arc::new(value),
+            data_type: DataType::Domain(name),
+        }
+    }
+
     pub fn from_any(value: Arc<dyn Any + Send + Sync>) -> Result<Self, String> {
         let type_id = (*value).type_id();
         let data_type = match type_id {
@@ -284,28 +352,31 @@ impl Data {
     }
 
     pub fn value<T: 'static>(&self) -> Result<&T, String> {
-        if self.data_type == DataType::Mesh {
-            // Mesh holds arbitrary types; bypass TypeId check and downcast directly
-            self.value.downcast_ref::<T>().ok_or_else(|| {
-                format!(
-                    "Mesh data downcast failed: requested {}",
-                    type_name::<T>()
-                )
-            })
-        } else if TypeId::of::<T>() == self.data_type.type_id() {
-            self.value.downcast_ref::<T>().ok_or_else(|| {
-                format!(
-                    "Data type mismatch: Expected {}, but got {}",
-                    self.data_type.type_name(),
-                    type_name::<T>()
-                )
-            })
-        } else {
-            Err(format!(
+        match self.data_type {
+            // Mesh, BRep, Domain hold arbitrary types; bypass TypeId check and downcast directly
+            DataType::Mesh | DataType::BRep | DataType::Domain(_) => {
+                self.value.downcast_ref::<T>().ok_or_else(|| {
+                    format!(
+                        "{} data downcast failed: requested {}",
+                        self.data_type.type_name(),
+                        type_name::<T>()
+                    )
+                })
+            }
+            _ if TypeId::of::<T>() == self.data_type.type_id() => {
+                self.value.downcast_ref::<T>().ok_or_else(|| {
+                    format!(
+                        "Data type mismatch: Expected {}, but got {}",
+                        self.data_type.type_name(),
+                        type_name::<T>()
+                    )
+                })
+            }
+            _ => Err(format!(
                 "Data type mismatch: Expected {}, but got {}",
                 self.data_type.type_name(),
                 type_name::<T>()
-            ))
+            )),
         }
     }
 

--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -51,7 +51,7 @@ impl DataType {
 
 pub type DataValue = Arc<dyn Any + Send + Sync>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Data {
     value: DataValue,
     data_type: DataType,

--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -52,6 +52,19 @@ impl ColorValue {
     }
 }
 
+/// A collection of 3D vertices with an open/closed flag.
+#[derive(Debug, Clone)]
+pub struct Vertices {
+    pub points: Vec<Vector3>,
+    pub closed: bool,
+}
+
+impl Vertices {
+    pub fn new(points: Vec<Vector3>, closed: bool) -> Self {
+        Self { points, closed }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub enum DataType {
     #[default]
@@ -64,6 +77,10 @@ pub enum DataType {
     Vector3,
     /// RGBA color value.
     Color,
+    /// A collection of vertices with an open/closed flag.
+    Vertices,
+    /// A boolean value.
+    Bool,
 }
 
 impl DataType {
@@ -75,6 +92,8 @@ impl DataType {
             DataType::Mesh => TypeId::of::<()>(),
             DataType::Vector3 => TypeId::of::<Vector3>(),
             DataType::Color => TypeId::of::<ColorValue>(),
+            DataType::Vertices => TypeId::of::<Vertices>(),
+            DataType::Bool => TypeId::of::<bool>(),
         }
     }
 
@@ -85,6 +104,8 @@ impl DataType {
             DataType::Mesh => "Mesh",
             DataType::Vector3 => "Vector3",
             DataType::Color => "Color",
+            DataType::Vertices => "Vertices",
+            DataType::Bool => "Bool",
         }
     }
 
@@ -100,6 +121,8 @@ impl DataType {
             DataType::Mesh => true,
             DataType::Vector3 => value.downcast_ref::<Vector3>().is_some(),
             DataType::Color => value.downcast_ref::<ColorValue>().is_some(),
+            DataType::Vertices => value.downcast_ref::<Vertices>().is_some(),
+            DataType::Bool => value.downcast_ref::<bool>().is_some(),
         }
     }
 }
@@ -140,6 +163,16 @@ impl Serialize for Data {
             DataType::Color => Err(serde::ser::Error::custom(
                 "Color data type is not serializable",
             )),
+            DataType::Vertices => Err(serde::ser::Error::custom(
+                "Vertices data type is not serializable",
+            )),
+            DataType::Bool => {
+                let value = self
+                    .value
+                    .downcast_ref::<bool>()
+                    .ok_or_else(|| serde::ser::Error::custom("Failed to downcast value to bool"))?;
+                serializer.serialize_bool(*value)
+            }
         }
     }
 }
@@ -177,6 +210,16 @@ impl<'de> Deserialize<'de> for Data {
                     data_type: DataType::String,
                 })
             }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Data {
+                    value: Arc::new(value),
+                    data_type: DataType::Bool,
+                })
+            }
         }
 
         deserializer.deserialize_any(DataVisitor)
@@ -192,6 +235,8 @@ impl Data {
             t if t == TypeId::of::<String>() => DataType::String,
             t if t == TypeId::of::<Vector3>() => DataType::Vector3,
             t if t == TypeId::of::<ColorValue>() => DataType::Color,
+            t if t == TypeId::of::<Vertices>() => DataType::Vertices,
+            t if t == TypeId::of::<bool>() => DataType::Bool,
             _ => return Err(format!("Invalid DataType: {}", type_name::<T>())),
         };
 
@@ -220,6 +265,8 @@ impl Data {
             t if t == TypeId::of::<String>() => DataType::String,
             t if t == TypeId::of::<Vector3>() => DataType::Vector3,
             t if t == TypeId::of::<ColorValue>() => DataType::Color,
+            t if t == TypeId::of::<Vertices>() => DataType::Vertices,
+            t if t == TypeId::of::<bool>() => DataType::Bool,
             _ => return Err("Unsupported data type".to_string()),
         };
 

--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -20,6 +20,9 @@ pub enum DataType {
     #[default]
     Number,
     String,
+    /// Mesh data type for geometry outputs.
+    /// Stores arbitrary mesh data as `Arc<dyn Any>` via `Data::from_mesh()`.
+    Mesh,
 }
 
 impl DataType {
@@ -27,6 +30,8 @@ impl DataType {
         match self {
             DataType::Number => TypeId::of::<f64>(),
             DataType::String => TypeId::of::<String>(),
+            // Mesh holds arbitrary types; type_id is not used for Mesh (see Data::value())
+            DataType::Mesh => TypeId::of::<()>(),
         }
     }
 
@@ -34,6 +39,7 @@ impl DataType {
         match self {
             DataType::Number => type_name::<f64>(),
             DataType::String => type_name::<String>(),
+            DataType::Mesh => "Mesh",
         }
     }
 
@@ -45,6 +51,8 @@ impl DataType {
         match self {
             DataType::Number => value.downcast_ref::<f64>().is_some(),
             DataType::String => value.downcast_ref::<String>().is_some(),
+            // Mesh accepts any type
+            DataType::Mesh => true,
         }
     }
 }
@@ -62,22 +70,23 @@ impl Serialize for Data {
     where
         S: serde::Serializer,
     {
-        let type_name = self.data_type.type_name();
-        match type_name {
-            "f64" => {
+        match self.data_type {
+            DataType::Number => {
                 let value = self
                     .value
                     .downcast_ref::<f64>()
                     .ok_or_else(|| serde::ser::Error::custom("Failed to downcast value to f64"))?;
                 serializer.serialize_f64(*value)
             }
-            "alloc::string::String" => {
+            DataType::String => {
                 let value = self.value.downcast_ref::<String>().ok_or_else(|| {
                     serde::ser::Error::custom("Failed to downcast value to String")
                 })?;
                 serializer.serialize_str(value)
             }
-            _ => Err(serde::ser::Error::custom("Unsupported data type")),
+            DataType::Mesh => Err(serde::ser::Error::custom(
+                "Mesh data type is not serializable",
+            )),
         }
     }
 }
@@ -137,6 +146,18 @@ impl Data {
         })
     }
 
+    /// Create a Mesh data value from any type.
+    ///
+    /// Mesh data holds arbitrary types as `Arc<dyn Any>`, allowing custom
+    /// geometry types to flow through the graph without cognet needing
+    /// to know about them.
+    pub fn from_mesh<T: Any + Send + Sync + 'static>(value: T) -> Self {
+        Data {
+            value: Arc::new(value),
+            data_type: DataType::Mesh,
+        }
+    }
+
     pub fn from_any(value: Arc<dyn Any + Send + Sync>) -> Result<Self, String> {
         let type_id = (*value).type_id();
         let data_type = match type_id {
@@ -159,7 +180,15 @@ impl Data {
     }
 
     pub fn value<T: 'static>(&self) -> Result<&T, String> {
-        if TypeId::of::<T>() == self.data_type.type_id() {
+        if self.data_type == DataType::Mesh {
+            // Mesh holds arbitrary types; bypass TypeId check and downcast directly
+            self.value.downcast_ref::<T>().ok_or_else(|| {
+                format!(
+                    "Mesh data downcast failed: requested {}",
+                    type_name::<T>()
+                )
+            })
+        } else if TypeId::of::<T>() == self.data_type.type_id() {
             self.value.downcast_ref::<T>().ok_or_else(|| {
                 format!(
                     "Data type mismatch: Expected {}, but got {}",

--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::{impl_entity_id, EdgeId};
+use crate::impl_entity_id;
 use serde::{Deserialize, Serialize};
 
 impl_entity_id!(InputSlotId);
@@ -15,7 +15,7 @@ pub enum SlotId {
     Output(OutputSlotId),
 }
 
-#[derive(Debug, PartialEq, Default, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub enum DataType {
     #[default]
     Number,
@@ -188,7 +188,6 @@ pub struct InputSlot {
     pub data_type: DataType,
     pub default_value: Option<DataValue>,
     pub max_connections: Option<usize>,
-    pub connected_edges: Vec<EdgeId>,
 }
 
 impl InputSlot {
@@ -228,10 +227,6 @@ impl InputSlot {
     pub fn max_connections(&self) -> &Option<usize> {
         &self.max_connections
     }
-
-    pub fn connected_edges(&self) -> &Vec<EdgeId> {
-        &self.connected_edges
-    }
 }
 
 #[derive(Debug, Default)]
@@ -239,5 +234,4 @@ pub struct OutputSlot {
     pub id: OutputSlotId,
     pub label: &'static str,
     pub data_type: DataType,
-    pub connected_edges: Vec<EdgeId>,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,171 @@
+//! Structured error types for the graph engine.
+
+use crate::{DataType, EdgeId, NodeId};
+use std::fmt;
+
+/// Target of an error in the graph.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ErrorTarget {
+    /// Error on a node.
+    Node(NodeId),
+    /// Error on an input port.
+    InputPort { node_id: NodeId, slot_index: usize },
+    /// Error on an output port.
+    OutputPort { node_id: NodeId, slot_index: usize },
+    /// Error on an edge.
+    Edge(EdgeId),
+    /// Error on the graph itself (no specific target).
+    Graph,
+}
+
+/// Kind of graph error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErrorKind {
+    /// Type mismatch between ports.
+    TypeMismatch {
+        from_type: DataType,
+        to_type: DataType,
+    },
+    /// Connection limit exceeded on input port.
+    ConnectionLimitExceeded { max: usize },
+    /// Node not found.
+    NodeNotFound,
+    /// Slot not found.
+    SlotNotFound,
+    /// Cycle detected in graph.
+    CycleDetected,
+    /// Execution error.
+    Execution(String),
+    /// Other error.
+    Other(String),
+}
+
+/// Structured graph error.
+#[derive(Debug, Clone)]
+pub struct GraphError {
+    /// The target of the error.
+    pub target: ErrorTarget,
+    /// The kind of error.
+    pub kind: ErrorKind,
+}
+
+impl GraphError {
+    /// Create a new graph error.
+    pub fn new(target: ErrorTarget, kind: ErrorKind) -> Self {
+        Self { target, kind }
+    }
+
+    /// Create a type mismatch error.
+    pub fn type_mismatch(
+        node_id: NodeId,
+        slot_index: usize,
+        from_type: DataType,
+        to_type: DataType,
+    ) -> Self {
+        Self {
+            target: ErrorTarget::InputPort {
+                node_id,
+                slot_index,
+            },
+            kind: ErrorKind::TypeMismatch { from_type, to_type },
+        }
+    }
+
+    /// Create a connection limit exceeded error.
+    pub fn connection_limit_exceeded(node_id: NodeId, slot_index: usize, max: usize) -> Self {
+        Self {
+            target: ErrorTarget::InputPort {
+                node_id,
+                slot_index,
+            },
+            kind: ErrorKind::ConnectionLimitExceeded { max },
+        }
+    }
+
+    /// Create a node not found error.
+    pub fn node_not_found(node_id: NodeId) -> Self {
+        Self {
+            target: ErrorTarget::Node(node_id),
+            kind: ErrorKind::NodeNotFound,
+        }
+    }
+
+    /// Create a slot not found error for input.
+    pub fn input_slot_not_found(node_id: NodeId, slot_index: usize) -> Self {
+        Self {
+            target: ErrorTarget::InputPort {
+                node_id,
+                slot_index,
+            },
+            kind: ErrorKind::SlotNotFound,
+        }
+    }
+
+    /// Create a slot not found error for output.
+    pub fn output_slot_not_found(node_id: NodeId, slot_index: usize) -> Self {
+        Self {
+            target: ErrorTarget::OutputPort {
+                node_id,
+                slot_index,
+            },
+            kind: ErrorKind::SlotNotFound,
+        }
+    }
+
+    /// Create an execution error.
+    pub fn execution(node_id: NodeId, message: impl Into<String>) -> Self {
+        Self {
+            target: ErrorTarget::Node(node_id),
+            kind: ErrorKind::Execution(message.into()),
+        }
+    }
+
+    /// Create a cycle detected error.
+    pub fn cycle_detected() -> Self {
+        Self {
+            target: ErrorTarget::Graph,
+            kind: ErrorKind::CycleDetected,
+        }
+    }
+
+    /// Get the display message for this error.
+    pub fn message(&self) -> String {
+        match &self.kind {
+            ErrorKind::TypeMismatch { from_type, to_type } => {
+                format!(
+                    "Type mismatch: cannot connect {:?} to {:?}",
+                    from_type, to_type
+                )
+            }
+            ErrorKind::ConnectionLimitExceeded { max } => {
+                format!("Connection limit exceeded: maximum {} connection(s)", max)
+            }
+            ErrorKind::NodeNotFound => "Node not found".to_string(),
+            ErrorKind::SlotNotFound => "Slot not found".to_string(),
+            ErrorKind::CycleDetected => "Cycle detected in graph".to_string(),
+            ErrorKind::Execution(msg) => format!("Execution error: {}", msg),
+            ErrorKind::Other(msg) => msg.clone(),
+        }
+    }
+
+    /// Check if this is a connection-related error (for UI highlighting).
+    pub fn is_connection_error(&self) -> bool {
+        matches!(
+            self.kind,
+            ErrorKind::TypeMismatch { .. } | ErrorKind::ConnectionLimitExceeded { .. }
+        )
+    }
+
+    /// Check if this is an execution error.
+    pub fn is_execution_error(&self) -> bool {
+        matches!(self.kind, ErrorKind::Execution(_))
+    }
+}
+
+impl fmt::Display for GraphError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message())
+    }
+}
+
+impl std::error::Error for GraphError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod edge;
+pub mod error;
 pub mod node;
 pub mod node_graph;
 pub mod utils;
 
 pub use edge::*;
+pub use error::*;
 pub use node::*;
 pub use node_graph::*;
 pub use utils::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,12 @@ pub mod edge;
 pub mod error;
 pub mod node;
 pub mod node_graph;
+pub mod state_access;
 pub mod utils;
 
 pub use edge::*;
 pub use error::*;
 pub use node::*;
 pub use node_graph::*;
+pub use state_access::*;
 pub use utils::*;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,11 +1,13 @@
 pub mod operators;
 pub mod outputs;
 pub mod primitives;
+pub mod subgraph;
 pub mod type_info;
 
 pub use operators::*;
 pub use outputs::*;
 pub use primitives::*;
+pub use subgraph::*;
 pub use type_info::*;
 
 use crate::{impl_entity_id, AsAny, Data, InputSlot, NodeManager, OutputSlot, SharedExecutionCache};

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -218,16 +218,7 @@ macro_rules! register_nodes {
                 fn register_in(manager: &mut $crate::NodeManager) -> Result<(), String> {
                     let factory = std::sync::Arc::new(|| {
                         <$struct_name as $crate::NodeInit>::initialize().map(|node| {
-                            std::sync::Arc::new({
-                                #[cfg(target_arch = "wasm32")]
-                                {
-                                    async_lock::RwLock::new(node)
-                                }
-                                #[cfg(not(target_arch = "wasm32"))]
-                                {
-                                    tokio::sync::RwLock::new(node)
-                                }
-                            }) as $crate::NodeEntity
+                            std::sync::Arc::new(std::sync::RwLock::new(node)) as $crate::NodeEntity
                         })
                     });
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,22 +1,33 @@
 pub mod operators;
+pub mod outputs;
 pub mod primitives;
+pub mod type_info;
 
 pub use operators::*;
+pub use outputs::*;
 pub use primitives::*;
+pub use type_info::*;
 
-use crate::{
-    impl_entity_id, AsAny, Data, InputSlot, NodeManager, OutputSlot, SharedExecutionCache,
-};
+use crate::{impl_entity_id, AsAny, Data, InputSlot, NodeManager, OutputSlot, SharedExecutionCache};
 use std::{any::Any, fmt::Debug};
 
 impl_entity_id!(NodeId);
 
+/// Trait for node initialization.
+/// This is automatically implemented by the `register_nodes!` macro.
+pub trait NodeInit: NodeMeta + Sized {
+    /// Initialize a new node instance.
+    /// The default implementation creates a node with:
+    /// - `node_data` from `NodeMeta::default_data()`
+    /// - `inputs` from `NodeMeta::INPUTS`
+    /// - `outputs` from `NodeMeta::OUTPUTS`
+    fn initialize() -> Result<Self, String>;
+}
+
+/// The core node implementation trait.
+/// Only requires `execute()` - initialization is handled by `NodeInit`.
 #[async_trait::async_trait]
 pub trait NodeImpl: Debug + Send + Sync + AsAny {
-    fn initialize() -> Result<Self, String>
-    where
-        Self: Sized;
-
     async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String>;
 }
 
@@ -41,19 +52,26 @@ pub trait NodeCore: Debug {
             .get(slot_index)
             .ok_or("Invalid slot index".to_string())?;
 
+        let expected_type = input_slot.data_type;
+
         let cache = cache.lock()?;
-        let result: Vec<Data> = input_slot
-            .connected_edges
-            .iter()
-            .filter_map(|edge_id| {
-                cache.edges.get(edge_id).and_then(|edge| {
-                    cache
-                        .outputs
-                        .get(&edge.from_output_slot_id)
-                        .and_then(|data| Some(data.share()))
-                })
-            })
-            .collect();
+        let mut result: Vec<Data> = Vec::new();
+
+        for edge_id in cache.edges_for_input(&input_slot.id) {
+            if let Some(edge) = cache.edges.get(edge_id) {
+                if let Some(data) = cache.outputs.get(&edge.from_output_slot_id) {
+                    // Validate type matches
+                    if data.get_type() != expected_type {
+                        return Err(format!(
+                            "Type mismatch: expected {:?}, got {:?}",
+                            expected_type,
+                            data.get_type()
+                        ));
+                    }
+                    result.push(data.share());
+                }
+            }
+        }
 
         Ok(result)
     }
@@ -153,11 +171,21 @@ impl<T: 'static + NodeCore> AsAny for T {
 macro_rules! register_nodes {
     ($($struct_name:ident),*) => {
         $(
+            impl $crate::NodeInit for $struct_name {
+                fn initialize() -> Result<Self, String> {
+                    Ok(Self {
+                        node_data: <Self as $crate::NodeMeta>::DEFAULT_VALUE.to_data(),
+                        inputs: $crate::inputs_from_defs(<Self as $crate::NodeMeta>::INPUTS),
+                        outputs: $crate::outputs_from_defs(<Self as $crate::NodeMeta>::OUTPUTS),
+                    })
+                }
+            }
+
             impl $crate::NodeValueSetter for $struct_name {}
 
             impl $crate::NodeCore for $struct_name {
                 fn node_name(&self) -> &'static str {
-                    self.node_name
+                    <$struct_name as $crate::NodeMeta>::NAME
                 }
 
                 fn node_data(&self) -> Option<$crate::Data> {
@@ -188,8 +216,8 @@ macro_rules! register_nodes {
                 }
 
                 fn register_in(manager: &mut $crate::NodeManager) -> Result<(), String> {
-                    manager.register_factory::<$struct_name>(std::sync::Arc::new(|| {
-                        $struct_name::initialize().map(|node| {
+                    let factory = std::sync::Arc::new(|| {
+                        <$struct_name as $crate::NodeInit>::initialize().map(|node| {
                             std::sync::Arc::new({
                                 #[cfg(target_arch = "wasm32")]
                                 {
@@ -201,10 +229,34 @@ macro_rules! register_nodes {
                                 }
                             }) as $crate::NodeEntity
                         })
-                    }))
+                    });
+
+                    // Register by TypeId for compile-time dispatch
+                    manager.register_factory::<$struct_name>(factory.clone())?;
+
+                    // Register by name for runtime dispatch
+                    manager.register_factory_with_name(
+                        <$struct_name as $crate::NodeMeta>::NAME,
+                        factory,
+                        <$struct_name as $crate::NodeMeta>::DEFAULT_VALUE.to_data(),
+                    );
+
+                    Ok(())
                 }
             }
 
+            // Register NodeTypeInfo for static metadata access
+            inventory::submit! {
+                $crate::NodeTypeInfo {
+                    name: <$struct_name as $crate::NodeMeta>::NAME,
+                    category: <$struct_name as $crate::NodeMeta>::CATEGORY,
+                    inputs: <$struct_name as $crate::NodeMeta>::INPUTS,
+                    outputs: <$struct_name as $crate::NodeMeta>::OUTPUTS,
+                    default_value: <$struct_name as $crate::NodeMeta>::DEFAULT_VALUE,
+                }
+            }
+
+            // Register factory for node creation
             inventory::submit! {
                 $crate::NodeRegistrationEntry {
                     register: $struct_name::register_in,

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -54,7 +54,7 @@ pub trait NodeCore: Debug {
 
         let expected_type = input_slot.data_type;
 
-        let cache = cache.lock()?;
+        let cache = cache.read()?;
         let mut result: Vec<Data> = Vec::new();
 
         for edge_id in cache.edges_for_input(&input_slot.id) {

--- a/src/node/operators/add_list.rs
+++ b/src/node/operators/add_list.rs
@@ -1,0 +1,42 @@
+use crate::{
+    register_nodes, Data, DataType, InputSlot, NodeCategory, NodeCore, NodeImpl, NodeMeta,
+    NodeValueSetter, OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+/// Adds all input numbers together
+#[derive(Debug)]
+pub struct AddListNode {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for AddListNode {
+    const NAME: &'static str = "AddList";
+    const CATEGORY: NodeCategory = NodeCategory::Math;
+    const INPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Numbers",
+        data_type: DataType::Number,
+        max_connections: None,
+    }];
+    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Sum",
+        data_type: DataType::Number,
+        max_connections: None,
+    }];
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for AddListNode {
+    async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
+        let data_list = self.input_value(cache.share(), 0)?;
+        let mut result = 0.;
+        for data in data_list {
+            result += data.value()?;
+        }
+        self.set_output_data(cache, 0, Data::new(result)?)?;
+        Ok(())
+    }
+}
+
+register_nodes!(AddListNode);

--- a/src/node/operators/divide.rs
+++ b/src/node/operators/divide.rs
@@ -1,0 +1,64 @@
+//! Divide operator node.
+//!
+//! Divides A by B. Returns 0.0 when B is zero.
+
+use crate::{
+    register_nodes, Data, DataType, InputSlot, NodeCategory, NodeCore, NodeImpl, NodeMeta,
+    NodeValueSetter, OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+/// Divides A by B (A / B)
+#[derive(Debug)]
+pub struct DivideNode {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for DivideNode {
+    const NAME: &'static str = "Divide";
+    const CATEGORY: NodeCategory = NodeCategory::Math;
+    const INPUTS: &'static [SlotDef] = &[
+        SlotDef {
+            label: "A",
+            data_type: DataType::Number,
+            max_connections: Some(1),
+        },
+        SlotDef {
+            label: "B",
+            data_type: DataType::Number,
+            max_connections: Some(1),
+        },
+    ];
+    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Quotient",
+        data_type: DataType::Number,
+        max_connections: None,
+    }];
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for DivideNode {
+    async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
+        let a_values = self.input_value(cache.share(), 0)?;
+        let b_values = self.input_value(cache.share(), 1)?;
+
+        let mut a: f64 = 0.0;
+        for data in a_values {
+            a = *data.value()?;
+            break;
+        }
+
+        let mut b: f64 = 0.0;
+        for data in b_values {
+            b = *data.value()?;
+            break;
+        }
+
+        let result = if b == 0.0 { 0.0 } else { a / b };
+        self.set_output_data(cache, 0, Data::new(result)?)?;
+        Ok(())
+    }
+}
+
+register_nodes!(DivideNode);

--- a/src/node/operators/divide_list.rs
+++ b/src/node/operators/divide_list.rs
@@ -1,0 +1,53 @@
+//! Divide list operator node.
+//!
+//! Divides the first number by all subsequent numbers.
+//! Returns 0.0 when any divisor is zero.
+
+use crate::{
+    register_nodes, Data, DataType, InputSlot, NodeCategory, NodeCore, NodeImpl, NodeMeta,
+    NodeValueSetter, OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+/// Divides the first number by all subsequent numbers
+#[derive(Debug)]
+pub struct DivideListNode {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for DivideListNode {
+    const NAME: &'static str = "DivideList";
+    const CATEGORY: NodeCategory = NodeCategory::Math;
+    const INPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Numbers",
+        data_type: DataType::Number,
+        max_connections: None,
+    }];
+    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Quotient",
+        data_type: DataType::Number,
+        max_connections: None,
+    }];
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for DivideListNode {
+    async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
+        let data_list = self.input_value(cache.share(), 0)?;
+        let mut result: Option<f64> = None;
+        for data in data_list {
+            let value: f64 = *data.value()?;
+            match result {
+                None => result = Some(value),
+                Some(r) => {
+                    result = Some(if value == 0.0 { 0.0 } else { r / value });
+                }
+            }
+        }
+        self.set_output_data(cache, 0, Data::new(result.unwrap_or(0.0))?)?;
+        Ok(())
+    }
+}
+
+register_nodes!(DivideListNode);

--- a/src/node/operators/mod.rs
+++ b/src/node/operators/mod.rs
@@ -1,3 +1,13 @@
 pub mod add;
+pub mod add_list;
+pub mod multiply;
+pub mod multiply_list;
+pub mod subtract;
+pub mod subtract_list;
 
 pub use add::*;
+pub use add_list::*;
+pub use multiply::*;
+pub use multiply_list::*;
+pub use subtract::*;
+pub use subtract_list::*;

--- a/src/node/operators/mod.rs
+++ b/src/node/operators/mod.rs
@@ -1,5 +1,7 @@
 pub mod add;
 pub mod add_list;
+pub mod divide;
+pub mod divide_list;
 pub mod multiply;
 pub mod multiply_list;
 pub mod subtract;
@@ -7,6 +9,8 @@ pub mod subtract_list;
 
 pub use add::*;
 pub use add_list::*;
+pub use divide::*;
+pub use divide_list::*;
 pub use multiply::*;
 pub use multiply_list::*;
 pub use subtract::*;

--- a/src/node/operators/multiply.rs
+++ b/src/node/operators/multiply.rs
@@ -3,16 +3,15 @@ use crate::{
     NodeValueSetter, OutputSlot, SharedExecutionCache, SlotDef,
 };
 
-/// Adds two numbers (A + B)
 #[derive(Debug)]
-pub struct AddNode {
+pub struct MultiplyNode {
     pub node_data: Option<Data>,
     pub inputs: Vec<InputSlot>,
     pub outputs: Vec<OutputSlot>,
 }
 
-impl NodeMeta for AddNode {
-    const NAME: &'static str = "Add";
+impl NodeMeta for MultiplyNode {
+    const NAME: &'static str = "Multiply";
     const CATEGORY: NodeCategory = NodeCategory::Math;
     const INPUTS: &'static [SlotDef] = &[
         SlotDef {
@@ -27,14 +26,14 @@ impl NodeMeta for AddNode {
         },
     ];
     const OUTPUTS: &'static [SlotDef] = &[SlotDef {
-        label: "Sum",
+        label: "Product",
         data_type: DataType::Number,
         max_connections: None,
     }];
 }
 
 #[async_trait::async_trait]
-impl NodeImpl for AddNode {
+impl NodeImpl for MultiplyNode {
     async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
         let a_values = self.input_value(cache.share(), 0)?;
         let b_values = self.input_value(cache.share(), 1)?;
@@ -42,18 +41,18 @@ impl NodeImpl for AddNode {
         let mut a: f64 = 0.0;
         for data in a_values {
             a = *data.value()?;
-            break;
+            break; // Take first value only
         }
 
         let mut b: f64 = 0.0;
         for data in b_values {
             b = *data.value()?;
-            break;
+            break; // Take first value only
         }
 
-        self.set_output_data(cache, 0, Data::new(a + b)?)?;
+        self.set_output_data(cache, 0, Data::new(a * b)?)?;
         Ok(())
     }
 }
 
-register_nodes!(AddNode);
+register_nodes!(MultiplyNode);

--- a/src/node/operators/multiply_list.rs
+++ b/src/node/operators/multiply_list.rs
@@ -1,0 +1,42 @@
+use crate::{
+    register_nodes, Data, DataType, InputSlot, NodeCategory, NodeCore, NodeImpl, NodeMeta,
+    NodeValueSetter, OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+/// Multiplies all input numbers together
+#[derive(Debug)]
+pub struct MultiplyListNode {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for MultiplyListNode {
+    const NAME: &'static str = "MultiplyList";
+    const CATEGORY: NodeCategory = NodeCategory::Math;
+    const INPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Numbers",
+        data_type: DataType::Number,
+        max_connections: None,
+    }];
+    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Product",
+        data_type: DataType::Number,
+        max_connections: None,
+    }];
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for MultiplyListNode {
+    async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
+        let data_list = self.input_value(cache.share(), 0)?;
+        let mut result = 1.0;
+        for data in data_list {
+            result *= data.value()?;
+        }
+        self.set_output_data(cache, 0, Data::new(result)?)?;
+        Ok(())
+    }
+}
+
+register_nodes!(MultiplyListNode);

--- a/src/node/operators/subtract.rs
+++ b/src/node/operators/subtract.rs
@@ -3,16 +3,15 @@ use crate::{
     NodeValueSetter, OutputSlot, SharedExecutionCache, SlotDef,
 };
 
-/// Adds two numbers (A + B)
 #[derive(Debug)]
-pub struct AddNode {
+pub struct SubtractNode {
     pub node_data: Option<Data>,
     pub inputs: Vec<InputSlot>,
     pub outputs: Vec<OutputSlot>,
 }
 
-impl NodeMeta for AddNode {
-    const NAME: &'static str = "Add";
+impl NodeMeta for SubtractNode {
+    const NAME: &'static str = "Subtract";
     const CATEGORY: NodeCategory = NodeCategory::Math;
     const INPUTS: &'static [SlotDef] = &[
         SlotDef {
@@ -27,14 +26,14 @@ impl NodeMeta for AddNode {
         },
     ];
     const OUTPUTS: &'static [SlotDef] = &[SlotDef {
-        label: "Sum",
+        label: "Difference",
         data_type: DataType::Number,
         max_connections: None,
     }];
 }
 
 #[async_trait::async_trait]
-impl NodeImpl for AddNode {
+impl NodeImpl for SubtractNode {
     async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
         let a_values = self.input_value(cache.share(), 0)?;
         let b_values = self.input_value(cache.share(), 1)?;
@@ -42,18 +41,18 @@ impl NodeImpl for AddNode {
         let mut a: f64 = 0.0;
         for data in a_values {
             a = *data.value()?;
-            break;
+            break; // Take first value only
         }
 
         let mut b: f64 = 0.0;
         for data in b_values {
             b = *data.value()?;
-            break;
+            break; // Take first value only
         }
 
-        self.set_output_data(cache, 0, Data::new(a + b)?)?;
+        self.set_output_data(cache, 0, Data::new(a - b)?)?;
         Ok(())
     }
 }
 
-register_nodes!(AddNode);
+register_nodes!(SubtractNode);

--- a/src/node/operators/subtract_list.rs
+++ b/src/node/operators/subtract_list.rs
@@ -1,0 +1,46 @@
+use crate::{
+    register_nodes, Data, DataType, InputSlot, NodeCategory, NodeCore, NodeImpl, NodeMeta,
+    NodeValueSetter, OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+/// Subtracts all subsequent numbers from the first number
+#[derive(Debug)]
+pub struct SubtractListNode {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for SubtractListNode {
+    const NAME: &'static str = "SubtractList";
+    const CATEGORY: NodeCategory = NodeCategory::Math;
+    const INPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Numbers",
+        data_type: DataType::Number,
+        max_connections: None,
+    }];
+    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Difference",
+        data_type: DataType::Number,
+        max_connections: None,
+    }];
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for SubtractListNode {
+    async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
+        let data_list = self.input_value(cache.share(), 0)?;
+        let mut result: Option<f64> = None;
+        for data in data_list {
+            let value: f64 = *data.value()?;
+            match result {
+                None => result = Some(value),
+                Some(r) => result = Some(r - value),
+            }
+        }
+        self.set_output_data(cache, 0, Data::new(result.unwrap_or(0.0))?)?;
+        Ok(())
+    }
+}
+
+register_nodes!(SubtractListNode);

--- a/src/node/outputs/mod.rs
+++ b/src/node/outputs/mod.rs
@@ -1,0 +1,5 @@
+pub mod number_output;
+pub mod string_output;
+
+pub use number_output::*;
+pub use string_output::*;

--- a/src/node/outputs/number_output.rs
+++ b/src/node/outputs/number_output.rs
@@ -1,0 +1,33 @@
+use crate::{
+    register_nodes, Data, DataType, InputSlot, NodeCategory, NodeCore, NodeImpl, NodeMeta,
+    OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+#[derive(Debug)]
+pub struct NumberOutput {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for NumberOutput {
+    const NAME: &'static str = "Number Output";
+    const CATEGORY: NodeCategory = NodeCategory::Output;
+    const INPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Value",
+        data_type: DataType::Number,
+        max_connections: Some(1),
+    }];
+    const OUTPUTS: &'static [SlotDef] = &[];
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for NumberOutput {
+    async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
+        // Output node just reads its input - the value is read from cache for UI display
+        let _values = self.input_value(cache, 0)?;
+        Ok(())
+    }
+}
+
+register_nodes!(NumberOutput);

--- a/src/node/outputs/string_output.rs
+++ b/src/node/outputs/string_output.rs
@@ -1,0 +1,33 @@
+use crate::{
+    register_nodes, Data, DataType, InputSlot, NodeCategory, NodeCore, NodeImpl, NodeMeta,
+    OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+#[derive(Debug)]
+pub struct StringOutput {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for StringOutput {
+    const NAME: &'static str = "String Output";
+    const CATEGORY: NodeCategory = NodeCategory::Output;
+    const INPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Value",
+        data_type: DataType::String,
+        max_connections: Some(1),
+    }];
+    const OUTPUTS: &'static [SlotDef] = &[];
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for StringOutput {
+    async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
+        // Output node just reads its input - the value is read from cache for UI display
+        let _values = self.input_value(cache, 0)?;
+        Ok(())
+    }
+}
+
+register_nodes!(StringOutput);

--- a/src/node/primitives/color.rs
+++ b/src/node/primitives/color.rs
@@ -1,0 +1,45 @@
+//! Color primitive node.
+//!
+//! Outputs an RGBA color value. The node's data holds a `ColorValue`
+//! which is passed through to the output.
+
+use crate::{
+    register_nodes, Data, DataType, DefaultValue, InputSlot, NodeCategory, NodeCore, NodeImpl,
+    NodeMeta, NodeValueSetter, OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+/// A Color value node that outputs an RGBA color.
+#[derive(Debug)]
+pub struct ColorNode {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for ColorNode {
+    const NAME: &'static str = "Color";
+    const CATEGORY: NodeCategory = NodeCategory::Primitive;
+    const INPUTS: &'static [SlotDef] = &[];
+    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Value",
+        data_type: DataType::Color,
+        max_connections: None,
+    }];
+    const DEFAULT_VALUE: DefaultValue = DefaultValue::Color {
+        r: 255.0,
+        g: 255.0,
+        b: 255.0,
+        a: 255.0,
+    };
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for ColorNode {
+    async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
+        let node_data = self.node_data().ok_or("Failed to get node data")?;
+        self.set_output_data(cache, 0, node_data)?;
+        Ok(())
+    }
+}
+
+register_nodes!(ColorNode);

--- a/src/node/primitives/mod.rs
+++ b/src/node/primitives/mod.rs
@@ -1,3 +1,5 @@
 pub mod number;
+pub mod string;
 
 pub use number::*;
+pub use string::*;

--- a/src/node/primitives/mod.rs
+++ b/src/node/primitives/mod.rs
@@ -1,5 +1,11 @@
+pub mod color;
 pub mod number;
 pub mod string;
+pub mod vector3;
+pub mod vertex;
 
+pub use color::*;
 pub use number::*;
 pub use string::*;
+pub use vector3::*;
+pub use vertex::*;

--- a/src/node/primitives/string.rs
+++ b/src/node/primitives/string.rs
@@ -4,26 +4,26 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct NumberNode {
+pub struct StringNode {
     pub node_data: Option<Data>,
     pub inputs: Vec<InputSlot>,
     pub outputs: Vec<OutputSlot>,
 }
 
-impl NodeMeta for NumberNode {
-    const NAME: &'static str = "Number";
+impl NodeMeta for StringNode {
+    const NAME: &'static str = "String";
     const CATEGORY: NodeCategory = NodeCategory::Primitive;
     const INPUTS: &'static [SlotDef] = &[];
     const OUTPUTS: &'static [SlotDef] = &[SlotDef {
         label: "Value",
-        data_type: DataType::Number,
+        data_type: DataType::String,
         max_connections: None,
     }];
-    const DEFAULT_VALUE: DefaultValue = DefaultValue::Number(10.0);
+    const DEFAULT_VALUE: DefaultValue = DefaultValue::String("Hello");
 }
 
 #[async_trait::async_trait]
-impl NodeImpl for NumberNode {
+impl NodeImpl for StringNode {
     async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
         let node_data = self.node_data().ok_or("Failed to get node data")?;
         self.set_output_data(cache, 0, node_data)?;
@@ -31,4 +31,4 @@ impl NodeImpl for NumberNode {
     }
 }
 
-register_nodes!(NumberNode);
+register_nodes!(StringNode);

--- a/src/node/primitives/vector3.rs
+++ b/src/node/primitives/vector3.rs
@@ -1,0 +1,44 @@
+//! Vector3 primitive node.
+//!
+//! Outputs a 3D vector value. The node's data holds a `Vector3`
+//! which is passed through to the output.
+
+use crate::{
+    register_nodes, Data, DataType, DefaultValue, InputSlot, NodeCategory, NodeCore, NodeImpl,
+    NodeMeta, NodeValueSetter, OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+/// A Vector3 value node that outputs a 3D vector (x, y, z).
+#[derive(Debug)]
+pub struct Vector3Node {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for Vector3Node {
+    const NAME: &'static str = "Vector3";
+    const CATEGORY: NodeCategory = NodeCategory::Primitive;
+    const INPUTS: &'static [SlotDef] = &[];
+    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Value",
+        data_type: DataType::Vector3,
+        max_connections: None,
+    }];
+    const DEFAULT_VALUE: DefaultValue = DefaultValue::Vector3 {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for Vector3Node {
+    async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
+        let node_data = self.node_data().ok_or("Failed to get node data")?;
+        self.set_output_data(cache, 0, node_data)?;
+        Ok(())
+    }
+}
+
+register_nodes!(Vector3Node);

--- a/src/node/primitives/vertex.rs
+++ b/src/node/primitives/vertex.rs
@@ -1,0 +1,45 @@
+//! Vertex primitive node.
+//!
+//! Outputs a 3D vertex value. The node's data holds a `Vector3`
+//! which is passed through to the output. Semantically distinct from
+//! Vector3Node — Vertex represents a point/position in space.
+
+use crate::{
+    register_nodes, Data, DataType, DefaultValue, InputSlot, NodeCategory, NodeCore, NodeImpl,
+    NodeMeta, NodeValueSetter, OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+/// A Vertex value node that outputs a 3D position (x, y, z).
+#[derive(Debug)]
+pub struct VertexNode {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for VertexNode {
+    const NAME: &'static str = "Vertex";
+    const CATEGORY: NodeCategory = NodeCategory::Primitive;
+    const INPUTS: &'static [SlotDef] = &[];
+    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Value",
+        data_type: DataType::Vector3,
+        max_connections: None,
+    }];
+    const DEFAULT_VALUE: DefaultValue = DefaultValue::Vector3 {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for VertexNode {
+    async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
+        let node_data = self.node_data().ok_or("Failed to get node data")?;
+        self.set_output_data(cache, 0, node_data)?;
+        Ok(())
+    }
+}
+
+register_nodes!(VertexNode);

--- a/src/node/subgraph/input_proxy.rs
+++ b/src/node/subgraph/input_proxy.rs
@@ -1,0 +1,41 @@
+//! SubGraph input proxy node.
+//!
+//! Placed inside a subgraph to receive data from the parent graph's
+//! SubGraphNode input slots. Each output corresponds to one external input.
+
+#[allow(unused_imports)]
+use crate::{
+    Data, DefaultValue, InputSlot, NodeCategory, NodeCore, NodeImpl, NodeMeta, NodeValueSetter,
+    OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+/// Proxy node inside a subgraph that bridges external inputs.
+///
+/// During subgraph execution, external input data is injected into this node's
+/// outputs before the internal graph executes. Each output slot corresponds
+/// to one input slot on the parent SubGraphNode.
+#[derive(Debug)]
+pub struct SubGraphInputNode {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for SubGraphInputNode {
+    const NAME: &'static str = "SubGraphInput";
+    const CATEGORY: NodeCategory = NodeCategory::Utility;
+    const INPUTS: &'static [SlotDef] = &[];
+    const OUTPUTS: &'static [SlotDef] = &[];
+    const DEFAULT_VALUE: DefaultValue = DefaultValue::None;
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for SubGraphInputNode {
+    async fn execute(&self, _cache: SharedExecutionCache) -> Result<(), String> {
+        // Data is injected directly into outputs by SubGraphNode before execution.
+        // This node's execute is a no-op.
+        Ok(())
+    }
+}
+
+crate::register_nodes!(SubGraphInputNode);

--- a/src/node/subgraph/mod.rs
+++ b/src/node/subgraph/mod.rs
@@ -1,0 +1,517 @@
+//! SubGraph node system.
+//!
+//! A SubGraphNode contains a nested NodeGraph, allowing hierarchical
+//! graph composition. External inputs flow through SubGraphInputNode
+//! proxy, and internal results exit through SubGraphOutputNode proxy.
+
+pub mod input_proxy;
+pub mod output_proxy;
+
+pub use input_proxy::SubGraphInputNode;
+pub use output_proxy::SubGraphOutputNode;
+
+use std::sync::Arc;
+
+use crate::{
+    Data, DataType, InputSlot, NodeCategory, NodeCore, NodeGraph, NodeGraphAPI, NodeId, NodeImpl,
+    NodeManager, NodeMeta, NodeValueSetter, OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+/// A node that contains a nested NodeGraph.
+///
+/// SubGraphNode acts as a single node in the parent graph while internally
+/// containing a full computation graph. Inputs are bridged via
+/// SubGraphInputNode, and outputs via SubGraphOutputNode.
+///
+/// # Data Flow
+///
+/// ```text
+/// Parent Graph                    Internal Graph
+/// ┌──────────────────┐
+/// │  SubGraphNode    │
+/// │  ┌────────────┐  │
+/// │  │ InputProxy  ├──┼──> [internal nodes] ──> OutputProxy
+/// │  └────────────┘  │                          │
+/// │  outputs ◄───────┼──────────────────────────┘
+/// └──────────────────┘
+/// ```
+pub struct SubGraphNode {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+    /// The nested graph that this subgraph node manages.
+    internal_graph: NodeGraph,
+    /// NodeId of the SubGraphInputNode inside the internal graph.
+    input_proxy_id: NodeId,
+    /// NodeId of the SubGraphOutputNode inside the internal graph.
+    output_proxy_id: NodeId,
+    /// Label for UI display (e.g., "StairGroup").
+    label: String,
+    /// Number of proxy outputs each external input maps to.
+    /// Normally 1 (1:1 mapping). For multi-input ports like Baseline, this is N.
+    input_proxy_counts: Vec<usize>,
+}
+
+impl std::fmt::Debug for SubGraphNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubGraphNode")
+            .field("inputs", &self.inputs.len())
+            .field("outputs", &self.outputs.len())
+            .field("input_proxy_id", &self.input_proxy_id)
+            .field("output_proxy_id", &self.output_proxy_id)
+            .field("label", &self.label)
+            .field("input_proxy_counts", &self.input_proxy_counts)
+            .finish()
+    }
+}
+
+impl SubGraphNode {
+    /// Create a new SubGraphNode with empty internal graph.
+    pub fn new(label: impl Into<String>) -> Result<Self, String> {
+        let mut internal_graph = NodeGraph::new()?;
+        let input_proxy_id = internal_graph.create_node::<SubGraphInputNode>()?;
+        let output_proxy_id = internal_graph.create_node::<SubGraphOutputNode>()?;
+
+        Ok(Self {
+            node_data: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            internal_graph,
+            input_proxy_id,
+            output_proxy_id,
+            label: label.into(),
+            input_proxy_counts: Vec::new(),
+        })
+    }
+
+    /// Get a reference to the internal graph.
+    pub fn internal_graph(&self) -> &NodeGraph {
+        &self.internal_graph
+    }
+
+    /// Get a mutable reference to the internal graph.
+    pub fn internal_graph_mut(&mut self) -> &mut NodeGraph {
+        &mut self.internal_graph
+    }
+
+    /// Get the NodeId of the input proxy node inside the internal graph.
+    pub fn input_proxy_id(&self) -> NodeId {
+        self.input_proxy_id
+    }
+
+    /// Get the NodeId of the output proxy node inside the internal graph.
+    pub fn output_proxy_id(&self) -> NodeId {
+        self.output_proxy_id
+    }
+
+    /// Get the display label.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Set the display label.
+    pub fn set_label(&mut self, label: impl Into<String>) {
+        self.label = label.into();
+    }
+
+    /// Add an input slot to this subgraph node and a corresponding
+    /// output slot on the internal SubGraphInputNode.
+    pub fn add_input(&mut self, slot: InputSlot) -> Result<(), String> {
+        let data_type = slot.data_type;
+        let label = slot.label;
+        self.inputs.push(slot);
+        self.input_proxy_counts.push(1);
+
+        // Add corresponding output on the input proxy (with same label)
+        let proxy = self
+            .internal_graph
+            .get_node_by_id(&self.input_proxy_id)
+            .ok_or("Input proxy not found")?;
+        let mut write_proxy = proxy.write().map_err(|e| e.to_string())?;
+        let output_slot = OutputSlot {
+            label,
+            data_type,
+            ..Default::default()
+        };
+        write_proxy.outputs_mut().push(output_slot);
+        Ok(())
+    }
+
+    /// Add a single external input port that maps to multiple proxy outputs.
+    ///
+    /// Used for ports like "Baseline" where N edges connect to one input slot
+    /// and each edge value is distributed to a separate proxy output inside
+    /// the internal graph.
+    pub fn add_multi_input(
+        &mut self,
+        slot: InputSlot,
+        proxy_count: usize,
+        proxy_data_type: DataType,
+        proxy_label: &'static str,
+    ) -> Result<(), String> {
+        self.inputs.push(slot);
+        self.input_proxy_counts.push(proxy_count);
+
+        // Add proxy_count output slots on the input proxy
+        let proxy = self
+            .internal_graph
+            .get_node_by_id(&self.input_proxy_id)
+            .ok_or("Input proxy not found")?;
+        let mut write_proxy = proxy.write().map_err(|e| e.to_string())?;
+        for _ in 0..proxy_count {
+            write_proxy.outputs_mut().push(OutputSlot {
+                label: proxy_label,
+                data_type: proxy_data_type,
+                ..Default::default()
+            });
+        }
+        Ok(())
+    }
+
+    /// Remove the last input slot from this subgraph node and the
+    /// corresponding output slot(s) from the internal SubGraphInputNode.
+    ///
+    /// Returns an error if there are no inputs to remove.
+    pub fn remove_input(&mut self, index: usize) -> Result<(), String> {
+        if index >= self.inputs.len() {
+            return Err(format!(
+                "Input index {} out of range (have {})",
+                index,
+                self.inputs.len()
+            ));
+        }
+
+        // Calculate the proxy output range for this input
+        let proxy_start: usize = self.input_proxy_counts[..index].iter().sum();
+        let proxy_count = self.input_proxy_counts[index];
+
+        // Remove from proxy outputs
+        let proxy = self
+            .internal_graph
+            .get_node_by_id(&self.input_proxy_id)
+            .ok_or("Input proxy not found")?;
+        let mut write_proxy = proxy.write().map_err(|e| e.to_string())?;
+        for _ in 0..proxy_count {
+            if proxy_start < write_proxy.outputs().len() {
+                write_proxy.outputs_mut().remove(proxy_start);
+            }
+        }
+        drop(write_proxy);
+
+        // Remove from self
+        self.inputs.remove(index);
+        self.input_proxy_counts.remove(index);
+
+        Ok(())
+    }
+
+    /// Remove an output slot from this subgraph node and the
+    /// corresponding input slot from the internal SubGraphOutputNode.
+    ///
+    /// Returns an error if the index is out of range.
+    pub fn remove_output(&mut self, index: usize) -> Result<(), String> {
+        if index >= self.outputs.len() {
+            return Err(format!(
+                "Output index {} out of range (have {})",
+                index,
+                self.outputs.len()
+            ));
+        }
+
+        // Remove from proxy inputs
+        let proxy = self
+            .internal_graph
+            .get_node_by_id(&self.output_proxy_id)
+            .ok_or("Output proxy not found")?;
+        let mut write_proxy = proxy.write().map_err(|e| e.to_string())?;
+        if index < write_proxy.inputs().len() {
+            write_proxy.inputs_mut().remove(index);
+        }
+        drop(write_proxy);
+
+        // Remove from self
+        self.outputs.remove(index);
+
+        Ok(())
+    }
+
+    /// Add an output slot to this subgraph node and a corresponding
+    /// input slot on the internal SubGraphOutputNode.
+    pub fn add_output(&mut self, slot: OutputSlot) -> Result<(), String> {
+        let data_type = slot.data_type;
+        let label = slot.label;
+        self.outputs.push(slot);
+
+        // Add corresponding input on the output proxy (with same label)
+        let proxy = self
+            .internal_graph
+            .get_node_by_id(&self.output_proxy_id)
+            .ok_or("Output proxy not found")?;
+        let mut write_proxy = proxy.write().map_err(|e| e.to_string())?;
+        let input_slot = InputSlot {
+            label,
+            data_type,
+            ..Default::default()
+        };
+        write_proxy.inputs_mut().push(input_slot);
+        Ok(())
+    }
+
+    /// Set the default value for an input port.
+    /// Used for promoted properties - when not connected, this value is injected.
+    pub fn set_input_default(&mut self, input_index: usize, data: Data) -> Result<(), String> {
+        let slot = self
+            .inputs
+            .get_mut(input_index)
+            .ok_or_else(|| format!("Input index {} out of range", input_index))?;
+        slot.set_default_value(data)
+    }
+
+    /// Inject external input data into the internal input proxy's output cache.
+    ///
+    /// Uses a cursor to map external inputs to proxy outputs:
+    /// - For normal inputs (count=1): one value → one proxy output (with default fallback)
+    /// - For multi-inputs (count>1): N edge values → N proxy outputs (no default)
+    fn inject_inputs(&self, parent_cache: SharedExecutionCache) -> Result<(), String> {
+        let proxy = self
+            .internal_graph
+            .get_node_by_id(&self.input_proxy_id)
+            .ok_or("Input proxy not found")?;
+        let read_proxy = proxy.read().map_err(|e| e.to_string())?;
+        let internal_cache = self.internal_graph.shared_cache();
+
+        let mut proxy_cursor: usize = 0;
+
+        for (idx, input_slot) in self.inputs.iter().enumerate() {
+            let count = self.input_proxy_counts.get(idx).copied().unwrap_or(1);
+
+            // Collect all edge values for this input slot
+            let parent_cache_read = parent_cache.read()?;
+            let mut data_values = Vec::new();
+            for edge_id in parent_cache_read.edges_for_input(&input_slot.id) {
+                if let Some(edge) = parent_cache_read.edges.get(edge_id) {
+                    if let Some(data) = parent_cache_read.outputs.get(&edge.from_output_slot_id) {
+                        data_values.push(data.share());
+                    }
+                }
+            }
+            drop(parent_cache_read);
+
+            if count == 1 {
+                // Normal 1:1 mapping with default value fallback
+                if let Some(data) = data_values.into_iter().next() {
+                    if let Some(proxy_output_slot) = read_proxy.outputs().get(proxy_cursor) {
+                        let mut cache = internal_cache.lock()?;
+                        cache.outputs.insert(proxy_output_slot.id, data);
+                    }
+                } else if let Some(default_ref) = input_slot.default_value.as_ref() {
+                    if let Ok(default_data) = Data::from_any(Arc::clone(default_ref)) {
+                        if let Some(proxy_output_slot) = read_proxy.outputs().get(proxy_cursor) {
+                            let mut cache = internal_cache.lock()?;
+                            cache.outputs.insert(proxy_output_slot.id, default_data);
+                        }
+                    }
+                }
+            } else {
+                // Multi-input: distribute N edge values to N proxy outputs
+                let distribute_count = data_values.len().min(count);
+                for i in 0..distribute_count {
+                    if let Some(proxy_output_slot) = read_proxy.outputs().get(proxy_cursor + i) {
+                        let mut cache = internal_cache.lock()?;
+                        cache
+                            .outputs
+                            .insert(proxy_output_slot.id, data_values[i].share());
+                    }
+                }
+            }
+
+            proxy_cursor += count;
+        }
+
+        Ok(())
+    }
+
+    /// Execute the SubGraphNode with mutable access.
+    ///
+    /// Called by the parent graph's execution engine, which holds a write lock
+    /// on the node entity. This allows mutable access to the internal graph
+    /// for execution, which is not possible from `NodeImpl::execute(&self)`.
+    ///
+    /// Performs the full execution cycle:
+    /// 1. Inject external inputs into the internal input proxy
+    /// 2. Execute the internal graph (requires `&mut self`)
+    /// 3. Collect outputs from the internal output proxy
+    pub async fn execute_internal(
+        &mut self,
+        parent_cache: SharedExecutionCache,
+    ) -> Result<(), String> {
+        self.inject_inputs(parent_cache.share())?;
+        // Mark all internal nodes dirty so they execute.
+        // This is needed because the internal graph doesn't know that
+        // its proxy inputs changed.
+        self.internal_graph.mark_all_nodes_dirty();
+        let _changes = self.internal_graph.execute().await?;
+        self.collect_outputs(parent_cache)?;
+        Ok(())
+    }
+
+    /// Read results from the internal output proxy and write to this node's outputs.
+    fn collect_outputs(&self, parent_cache: SharedExecutionCache) -> Result<(), String> {
+        let proxy = self
+            .internal_graph
+            .get_node_by_id(&self.output_proxy_id)
+            .ok_or("Output proxy not found")?;
+        let read_proxy = proxy.read().map_err(|e| e.to_string())?;
+        let internal_cache = self.internal_graph.shared_cache();
+
+        for (idx, output_slot) in self.outputs.iter().enumerate() {
+            // Read data from the output proxy's input in the internal cache
+            if let Some(proxy_input_slot) = read_proxy.inputs().get(idx) {
+                let cache_read = internal_cache.read()?;
+                // Find edges connected to this proxy input
+                for edge_id in cache_read.edges_for_input(&proxy_input_slot.id) {
+                    if let Some(edge) = cache_read.edges.get(edge_id) {
+                        if let Some(data) =
+                            cache_read.outputs.get(&edge.from_output_slot_id)
+                        {
+                            let data = data.share();
+                            drop(cache_read);
+                            // Write to parent cache output
+                            let mut parent_write = parent_cache.lock()?;
+                            parent_write.outputs.insert(output_slot.id, data);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl NodeMeta for SubGraphNode {
+    const NAME: &'static str = "SubGraph";
+    const CATEGORY: NodeCategory = NodeCategory::Utility;
+    // Dynamic slots - these constants are not used for SubGraphNode
+    const INPUTS: &'static [SlotDef] = &[];
+    const OUTPUTS: &'static [SlotDef] = &[];
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for SubGraphNode {
+    async fn execute(&self, cache: SharedExecutionCache) -> Result<(), String> {
+        // 1. Inject external inputs into internal input proxy outputs
+        self.inject_inputs(cache.share())?;
+
+        // 2. Execute the internal graph
+        // Note: We need mutable access for execute(), but we only have &self.
+        // The internal graph's dirty nodes are all nodes since we inject fresh inputs.
+        // We use the shared cache directly instead.
+        //
+        // For now, mark all internal nodes as dirty by creating a temporary mutable graph.
+        // This is a limitation - in practice, the UI layer will call execute() on
+        // the parent graph which owns SubGraphNode mutably.
+
+        // 3. Collect outputs from internal output proxy
+        self.collect_outputs(cache)?;
+
+        Ok(())
+    }
+}
+
+// Manual implementation of NodeCore (can't use register_nodes! with dynamic slots)
+impl NodeCore for SubGraphNode {
+    fn node_name(&self) -> &'static str {
+        "SubGraph"
+    }
+
+    fn node_data(&self) -> Option<Data> {
+        self.node_data.as_ref().map(|d| d.share())
+    }
+
+    fn node_data_mut(&mut self) -> &mut Option<Data> {
+        &mut self.node_data
+    }
+
+    fn inputs(&self) -> &Vec<InputSlot> {
+        &self.inputs
+    }
+
+    fn inputs_mut(&mut self) -> &mut Vec<InputSlot> {
+        &mut self.inputs
+    }
+
+    fn outputs(&self) -> &Vec<OutputSlot> {
+        &self.outputs
+    }
+
+    fn outputs_mut(&mut self) -> &mut Vec<OutputSlot> {
+        &mut self.outputs
+    }
+
+    fn register_in(manager: &mut NodeManager) -> Result<(), String> {
+        let factory = Arc::new(|| {
+            SubGraphNode::new("SubGraph").map(|node| {
+                Arc::new(std::sync::RwLock::new(node)) as crate::NodeEntity
+            })
+        });
+        manager.register_factory::<SubGraphNode>(factory.clone())?;
+        manager.register_factory_with_name("SubGraph", factory, None);
+        Ok(())
+    }
+}
+
+impl NodeValueSetter for SubGraphNode {}
+
+// Register the SubGraphNode factory
+inventory::submit! {
+    crate::NodeRegistrationEntry {
+        register: SubGraphNode::register_in,
+    }
+}
+
+inventory::submit! {
+    crate::NodeTypeInfo {
+        name: "SubGraph",
+        category: NodeCategory::Utility,
+        inputs: &[],
+        outputs: &[],
+        default_value: crate::DefaultValue::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NodeGraphAPI;
+
+    #[tokio::test]
+    async fn test_subgraph_creation() {
+        let mut graph = NodeGraph::new().expect("Failed to create graph");
+        let subgraph_id = graph.create_node::<SubGraphNode>().expect("Failed to create subgraph");
+
+        let node = graph.get_node_by_id(&subgraph_id).expect("Node not found");
+        let read = node.read().expect("Lock failed");
+        assert_eq!(read.node_name(), "SubGraph");
+        assert!(read.inputs().is_empty());
+        assert!(read.outputs().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_subgraph_has_proxies() {
+        let subgraph = SubGraphNode::new("Test").expect("Failed to create subgraph");
+        assert!(
+            subgraph
+                .internal_graph
+                .get_node_by_id(&subgraph.input_proxy_id)
+                .is_some()
+        );
+        assert!(
+            subgraph
+                .internal_graph
+                .get_node_by_id(&subgraph.output_proxy_id)
+                .is_some()
+        );
+    }
+}

--- a/src/node/subgraph/output_proxy.rs
+++ b/src/node/subgraph/output_proxy.rs
@@ -1,0 +1,41 @@
+//! SubGraph output proxy node.
+//!
+//! Placed inside a subgraph to collect results that will be forwarded
+//! to the parent graph's SubGraphNode output slots.
+
+#[allow(unused_imports)]
+use crate::{
+    Data, DefaultValue, InputSlot, NodeCategory, NodeCore, NodeImpl, NodeMeta, NodeValueSetter,
+    OutputSlot, SharedExecutionCache, SlotDef,
+};
+
+/// Proxy node inside a subgraph that bridges outputs to the parent.
+///
+/// After the internal graph executes, the SubGraphNode reads data from
+/// this node's inputs and writes them to its own output slots.
+/// Each input slot corresponds to one output slot on the parent SubGraphNode.
+#[derive(Debug)]
+pub struct SubGraphOutputNode {
+    pub node_data: Option<Data>,
+    pub inputs: Vec<InputSlot>,
+    pub outputs: Vec<OutputSlot>,
+}
+
+impl NodeMeta for SubGraphOutputNode {
+    const NAME: &'static str = "SubGraphOutput";
+    const CATEGORY: NodeCategory = NodeCategory::Utility;
+    const INPUTS: &'static [SlotDef] = &[];
+    const OUTPUTS: &'static [SlotDef] = &[];
+    const DEFAULT_VALUE: DefaultValue = DefaultValue::None;
+}
+
+#[async_trait::async_trait]
+impl NodeImpl for SubGraphOutputNode {
+    async fn execute(&self, _cache: SharedExecutionCache) -> Result<(), String> {
+        // This node simply holds input data that was written by internal nodes.
+        // SubGraphNode reads the data from this node's inputs after execution.
+        Ok(())
+    }
+}
+
+crate::register_nodes!(SubGraphOutputNode);

--- a/src/node/type_info.rs
+++ b/src/node/type_info.rs
@@ -3,7 +3,7 @@
 //! This module provides compile-time metadata about node types,
 //! allowing UI to access node information without async locks.
 
-use crate::{Data, DataType, InputSlot, OutputSlot};
+use crate::{ColorValue, Data, DataType, InputSlot, OutputSlot, Vector3};
 use std::collections::HashMap;
 
 /// Category for organizing nodes in the UI.
@@ -52,6 +52,10 @@ pub enum DefaultValue {
     Number(f64),
     /// A string default value.
     String(&'static str),
+    /// A 3D vector default value.
+    Vector3 { x: f64, y: f64, z: f64 },
+    /// An RGBA color default value.
+    Color { r: f64, g: f64, b: f64, a: f64 },
 }
 
 impl DefaultValue {
@@ -61,6 +65,8 @@ impl DefaultValue {
             DefaultValue::None => None,
             DefaultValue::Number(n) => Data::new(n).ok(),
             DefaultValue::String(s) => Data::new(s.to_string()).ok(),
+            DefaultValue::Vector3 { x, y, z } => Data::new(Vector3::new(x, y, z)).ok(),
+            DefaultValue::Color { r, g, b, a } => Data::new(ColorValue::new(r, g, b, a)).ok(),
         }
     }
 }

--- a/src/node/type_info.rs
+++ b/src/node/type_info.rs
@@ -1,0 +1,154 @@
+//! Static metadata for node types.
+//!
+//! This module provides compile-time metadata about node types,
+//! allowing UI to access node information without async locks.
+
+use crate::{Data, DataType, InputSlot, OutputSlot};
+use std::collections::HashMap;
+
+/// Category for organizing nodes in the UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NodeCategory {
+    /// Primitive value nodes (Number, String, etc.)
+    Primitive,
+    /// Mathematical operations (Add, Subtract, Multiply, etc.)
+    Math,
+    /// Output/display nodes
+    Output,
+    /// Logic operations (And, Or, Not, etc.)
+    Logic,
+    /// String manipulation
+    Text,
+    /// Control flow (If, Switch, etc.)
+    Control,
+    /// Input/Output operations
+    IO,
+    /// Utility nodes
+    Utility,
+}
+
+impl NodeCategory {
+    /// Get the display name for this category.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            NodeCategory::Primitive => "Primitive",
+            NodeCategory::Math => "Math",
+            NodeCategory::Output => "Output",
+            NodeCategory::Logic => "Logic",
+            NodeCategory::Text => "Text",
+            NodeCategory::Control => "Control",
+            NodeCategory::IO => "IO",
+            NodeCategory::Utility => "Utility",
+        }
+    }
+}
+
+/// Default value for a node, representable as a const.
+#[derive(Debug, Clone, Copy)]
+pub enum DefaultValue {
+    /// No default value.
+    None,
+    /// A numeric default value.
+    Number(f64),
+    /// A string default value.
+    String(&'static str),
+}
+
+impl DefaultValue {
+    /// Convert to Option<Data> at runtime.
+    pub fn to_data(self) -> Option<Data> {
+        match self {
+            DefaultValue::None => None,
+            DefaultValue::Number(n) => Data::new(n).ok(),
+            DefaultValue::String(s) => Data::new(s.to_string()).ok(),
+        }
+    }
+}
+
+/// Static definition of a slot (input or output port).
+#[derive(Debug, Clone, Copy)]
+pub struct SlotDef {
+    pub label: &'static str,
+    pub data_type: DataType,
+    pub max_connections: Option<usize>,
+}
+
+impl SlotDef {
+    /// Create an InputSlot from this definition.
+    pub fn to_input_slot(&self) -> InputSlot {
+        InputSlot {
+            label: self.label,
+            data_type: self.data_type,
+            max_connections: self.max_connections,
+            ..Default::default()
+        }
+    }
+
+    /// Create an OutputSlot from this definition.
+    pub fn to_output_slot(&self) -> OutputSlot {
+        OutputSlot {
+            label: self.label,
+            data_type: self.data_type,
+            ..Default::default()
+        }
+    }
+}
+
+/// Create InputSlots from a slice of SlotDefs.
+pub fn inputs_from_defs(defs: &[SlotDef]) -> Vec<InputSlot> {
+    defs.iter().map(|d| d.to_input_slot()).collect()
+}
+
+/// Create OutputSlots from a slice of SlotDefs.
+pub fn outputs_from_defs(defs: &[SlotDef]) -> Vec<OutputSlot> {
+    defs.iter().map(|d| d.to_output_slot()).collect()
+}
+
+/// Trait for nodes to provide static metadata.
+///
+/// Implement this trait to define compile-time metadata for a node type.
+/// The `register_nodes!` macro will automatically use this to register
+/// `NodeTypeInfo` in the inventory.
+pub trait NodeMeta {
+    const NAME: &'static str;
+    const CATEGORY: NodeCategory;
+    const INPUTS: &'static [SlotDef];
+    const OUTPUTS: &'static [SlotDef];
+    /// Default value for the node (optional).
+    /// Use `DefaultValue::Number(10.0)` or `DefaultValue::String("hello")` for nodes with initial data.
+    const DEFAULT_VALUE: DefaultValue = DefaultValue::None;
+}
+
+/// Static metadata about a node type.
+///
+/// This is registered via `inventory` and can be queried at runtime
+/// without any async locks.
+#[derive(Debug, Clone, Copy)]
+pub struct NodeTypeInfo {
+    pub name: &'static str,
+    pub category: NodeCategory,
+    pub inputs: &'static [SlotDef],
+    pub outputs: &'static [SlotDef],
+    pub default_value: DefaultValue,
+}
+
+inventory::collect!(NodeTypeInfo);
+
+/// Get node type info by name.
+pub fn get_node_type_info(name: &str) -> Option<&'static NodeTypeInfo> {
+    inventory::iter::<NodeTypeInfo>().find(|info| info.name == name)
+}
+
+/// Get all registered node types.
+pub fn all_node_types() -> impl Iterator<Item = &'static NodeTypeInfo> {
+    inventory::iter::<NodeTypeInfo>()
+}
+
+/// Get node types grouped by category.
+pub fn node_types_by_category() -> HashMap<NodeCategory, Vec<&'static NodeTypeInfo>> {
+    let mut map: HashMap<NodeCategory, Vec<&'static NodeTypeInfo>> = HashMap::new();
+    for info in inventory::iter::<NodeTypeInfo>() {
+        map.entry(info.category).or_default().push(info);
+    }
+    map
+}

--- a/src/node/type_info.rs
+++ b/src/node/type_info.rs
@@ -56,6 +56,8 @@ pub enum DefaultValue {
     Vector3 { x: f64, y: f64, z: f64 },
     /// An RGBA color default value.
     Color { r: f64, g: f64, b: f64, a: f64 },
+    /// A boolean default value.
+    Bool(bool),
 }
 
 impl DefaultValue {
@@ -67,6 +69,7 @@ impl DefaultValue {
             DefaultValue::String(s) => Data::new(s.to_string()).ok(),
             DefaultValue::Vector3 { x, y, z } => Data::new(Vector3::new(x, y, z)).ok(),
             DefaultValue::Color { r, g, b, a } => Data::new(ColorValue::new(r, g, b, a)).ok(),
+            DefaultValue::Bool(b) => Data::new(b).ok(),
         }
     }
 }

--- a/src/node_graph/execution_cache.rs
+++ b/src/node_graph/execution_cache.rs
@@ -120,9 +120,30 @@ impl ExecutionCache {
     ///
     /// Call this after the application layer has consumed mesh data (e.g., uploaded
     /// to GPU) and no longer needs the cached copies.
+    ///
+    /// **Note:** This evicts ALL `DataType::Mesh` outputs regardless of the
+    /// concrete type stored inside. Use [`evict_mesh_outputs_of_type`] to evict
+    /// only outputs of a specific concrete type while keeping others.
     pub fn evict_mesh_outputs(&mut self) -> usize {
         let before = self.outputs.len();
         self.outputs.retain(|_, data| data.get_type() != DataType::Mesh);
+        before - self.outputs.len()
+    }
+
+    /// Remove `DataType::Mesh` outputs that contain a specific concrete type `T`.
+    ///
+    /// Unlike [`evict_mesh_outputs`], this only evicts Mesh outputs whose
+    /// `Arc<dyn Any>` payload can be downcast to `T`. Other Mesh-typed outputs
+    /// (e.g., intermediate data like `WindowDef` or `WallDefinition`) are preserved.
+    pub fn evict_mesh_outputs_of_type<T: 'static>(&mut self) -> usize {
+        let before = self.outputs.len();
+        self.outputs.retain(|_, data| {
+            if data.get_type() != DataType::Mesh {
+                return true; // keep non-mesh outputs
+            }
+            // Only evict if the concrete type matches T
+            data.value::<T>().is_err()
+        });
         before - self.outputs.len()
     }
 }

--- a/src/node_graph/execution_cache.rs
+++ b/src/node_graph/execution_cache.rs
@@ -16,7 +16,7 @@ impl SharedExecutionCache {
         }
     }
 
-    pub fn lock(&self) -> Result<MutexGuard<ExecutionCache>, String> {
+    pub fn lock(&self) -> Result<MutexGuard<'_, ExecutionCache>, String> {
         Ok(self.inner.lock().map_err(|_| "Failed to lock cache")?)
     }
 

--- a/src/node_graph/execution_cache.rs
+++ b/src/node_graph/execution_cache.rs
@@ -1,23 +1,33 @@
-use crate::{Data, Edge, EdgeId, InputSlotId, OutputSlotId};
+use crate::{Data, DataType, Edge, EdgeId, InputSlotId, NodeId, OutputSlotId};
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
 #[derive(Default, Clone)]
 pub struct SharedExecutionCache {
-    inner: Arc<Mutex<ExecutionCache>>,
+    inner: Arc<RwLock<ExecutionCache>>,
 }
 
 impl SharedExecutionCache {
     pub fn new(cache: ExecutionCache) -> Self {
         SharedExecutionCache {
-            inner: Arc::new(Mutex::new(cache)),
+            inner: Arc::new(RwLock::new(cache)),
         }
     }
 
-    pub fn lock(&self) -> Result<MutexGuard<'_, ExecutionCache>, String> {
-        Ok(self.inner.lock().map_err(|_| "Failed to lock cache")?)
+    /// Acquire a write lock (backward-compatible with existing callers).
+    pub fn lock(&self) -> Result<RwLockWriteGuard<'_, ExecutionCache>, String> {
+        self.inner
+            .write()
+            .map_err(|_| "Failed to lock cache".to_string())
+    }
+
+    /// Acquire a read lock for read-only access.
+    pub fn read(&self) -> Result<RwLockReadGuard<'_, ExecutionCache>, String> {
+        self.inner
+            .read()
+            .map_err(|_| "Failed to read cache".to_string())
     }
 
     pub fn share(&self) -> Self {
@@ -33,28 +43,51 @@ pub struct ExecutionCache {
     pub(crate) outputs: HashMap<OutputSlotId, Data>,
     /// Index for fast lookup of edges by input slot.
     pub(crate) input_connections: HashMap<InputSlotId, Vec<EdgeId>>,
+    /// Index for fast lookup of outgoing edges by source node.
+    pub(crate) outgoing_edges: HashMap<NodeId, Vec<EdgeId>>,
 }
 
 impl ExecutionCache {
-    /// Add an edge and update the input connection index.
+    /// Add an edge and update all connection indexes.
     pub fn add_edge(&mut self, edge_id: EdgeId, edge: Edge) {
         let input_slot_id = edge.to_input_slot_id;
+        let from_node_id = edge.from_node_id;
         self.edges.insert(edge_id, edge);
         self.input_connections
             .entry(input_slot_id)
             .or_default()
             .push(edge_id);
+        self.outgoing_edges
+            .entry(from_node_id)
+            .or_default()
+            .push(edge_id);
     }
 
-    /// Remove an edge and update the input connection index.
+    /// Remove an edge and update all connection indexes.
     pub fn remove_edge(&mut self, edge_id: &EdgeId) -> Option<Edge> {
         if let Some(edge) = self.edges.remove(edge_id) {
             if let Some(connections) = self.input_connections.get_mut(&edge.to_input_slot_id) {
                 connections.retain(|id| id != edge_id);
             }
+            if let Some(outgoing) = self.outgoing_edges.get_mut(&edge.from_node_id) {
+                outgoing.retain(|id| id != edge_id);
+            }
             Some(edge)
         } else {
             None
+        }
+    }
+
+    /// Remove all edges involving a node, maintaining all indexes.
+    pub fn remove_edges_for_node(&mut self, node_id: &NodeId) {
+        let edge_ids: Vec<EdgeId> = self
+            .edges
+            .iter()
+            .filter(|(_, edge)| edge.from_node_id == *node_id || edge.to_node_id == *node_id)
+            .map(|(id, _)| *id)
+            .collect();
+        for edge_id in edge_ids {
+            self.remove_edge(&edge_id);
         }
     }
 
@@ -66,8 +99,30 @@ impl ExecutionCache {
             .unwrap_or(&[])
     }
 
+    /// Get outgoing edge IDs from a node.
+    pub fn outgoing_edges_for_node(&self, node_id: &NodeId) -> &[EdgeId] {
+        self.outgoing_edges
+            .get(node_id)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
     /// Get output value by slot ID.
     pub fn get_output(&self, output_slot_id: &OutputSlotId) -> Option<&Data> {
         self.outputs.get(output_slot_id)
+    }
+
+    /// Remove all `DataType::Mesh` outputs from the cache.
+    ///
+    /// Frees `Arc<dyn Any>` payloads (typically containing mesh vertex/index data)
+    /// while preserving Number and String outputs needed for edge value display
+    /// and incremental re-execution.
+    ///
+    /// Call this after the application layer has consumed mesh data (e.g., uploaded
+    /// to GPU) and no longer needs the cached copies.
+    pub fn evict_mesh_outputs(&mut self) -> usize {
+        let before = self.outputs.len();
+        self.outputs.retain(|_, data| data.get_type() != DataType::Mesh);
+        before - self.outputs.len()
     }
 }

--- a/src/node_graph/execution_cache.rs
+++ b/src/node_graph/execution_cache.rs
@@ -1,10 +1,10 @@
-use crate::{Data, Edge, EdgeId, OutputSlotId};
+use crate::{Data, Edge, EdgeId, InputSlotId, OutputSlotId};
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex, MutexGuard},
 };
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct SharedExecutionCache {
     inner: Arc<Mutex<ExecutionCache>>,
 }
@@ -31,4 +31,43 @@ impl SharedExecutionCache {
 pub struct ExecutionCache {
     pub(crate) edges: HashMap<EdgeId, Edge>,
     pub(crate) outputs: HashMap<OutputSlotId, Data>,
+    /// Index for fast lookup of edges by input slot.
+    pub(crate) input_connections: HashMap<InputSlotId, Vec<EdgeId>>,
+}
+
+impl ExecutionCache {
+    /// Add an edge and update the input connection index.
+    pub fn add_edge(&mut self, edge_id: EdgeId, edge: Edge) {
+        let input_slot_id = edge.to_input_slot_id;
+        self.edges.insert(edge_id, edge);
+        self.input_connections
+            .entry(input_slot_id)
+            .or_default()
+            .push(edge_id);
+    }
+
+    /// Remove an edge and update the input connection index.
+    pub fn remove_edge(&mut self, edge_id: &EdgeId) -> Option<Edge> {
+        if let Some(edge) = self.edges.remove(edge_id) {
+            if let Some(connections) = self.input_connections.get_mut(&edge.to_input_slot_id) {
+                connections.retain(|id| id != edge_id);
+            }
+            Some(edge)
+        } else {
+            None
+        }
+    }
+
+    /// Get edges connected to an input slot.
+    pub fn edges_for_input(&self, input_slot_id: &InputSlotId) -> &[EdgeId] {
+        self.input_connections
+            .get(input_slot_id)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Get output value by slot ID.
+    pub fn get_output(&self, output_slot_id: &OutputSlotId) -> Option<&Data> {
+        self.outputs.get(output_slot_id)
+    }
 }

--- a/src/node_graph/mod.rs
+++ b/src/node_graph/mod.rs
@@ -3,11 +3,13 @@ pub mod node_graph_api;
 pub mod node_graph_system;
 pub mod node_manager;
 pub mod node_state;
+pub mod subgraph_ops;
 
 pub use execution_cache::*;
 pub use node_graph_api::*;
 pub use node_manager::*;
 pub use node_state::*;
+pub use subgraph_ops::*;
 
 use crate::{ErrorTarget, GraphError, NodeId, NodeStatesAccess};
 use std::collections::{HashMap, HashSet};
@@ -88,6 +90,15 @@ impl NodeGraph {
     /// Clear all execution errors (before running execute()).
     pub fn clear_execution_errors(&mut self) {
         self.errors.retain(|_, e| !e.is_execution_error());
+    }
+
+    /// Mark all nodes in the graph as dirty, forcing re-execution.
+    ///
+    /// Used by SubGraphNode to ensure all internal nodes execute
+    /// after external inputs are injected into the input proxy.
+    pub fn mark_all_nodes_dirty(&mut self) {
+        let all_ids: Vec<NodeId> = self.node_manager.all_node_ids();
+        self.dirty_nodes.extend(all_ids);
     }
 }
 

--- a/src/node_graph/mod.rs
+++ b/src/node_graph/mod.rs
@@ -2,18 +2,73 @@ pub mod execution_cache;
 pub mod node_graph_api;
 pub mod node_graph_system;
 pub mod node_manager;
+pub mod node_state;
 
 pub use execution_cache::*;
 pub use node_graph_api::*;
 pub use node_manager::*;
+pub use node_state::*;
 
-use crate::NodeId;
-use std::collections::HashSet;
+use crate::{ErrorTarget, GraphError, NodeId};
+use std::collections::{HashMap, HashSet};
 
 pub struct NodeGraph {
     node_manager: NodeManager,
+    node_states: SharedNodeStates,
     cache: SharedExecutionCache,
     dirty_nodes: HashSet<NodeId>,
+    /// Current errors in the graph, keyed by target.
+    errors: HashMap<ErrorTarget, GraphError>,
+}
+
+impl NodeGraph {
+    /// Get shared node states (for sync UI access).
+    ///
+    /// This returns a clone of the Arc, allowing external code
+    /// to access node states without holding the graph lock.
+    pub fn shared_node_states(&self) -> SharedNodeStates {
+        self.node_states.share()
+    }
+
+    /// Get shared execution cache (for UI access to output values).
+    pub fn shared_cache(&self) -> SharedExecutionCache {
+        self.cache.share()
+    }
+
+    /// Get all current errors.
+    pub fn errors(&self) -> &HashMap<ErrorTarget, GraphError> {
+        &self.errors
+    }
+
+    /// Check if there are any errors.
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    /// Get error for a specific target.
+    pub fn error_for(&self, target: &ErrorTarget) -> Option<&GraphError> {
+        self.errors.get(target)
+    }
+
+    /// Add an error.
+    pub fn add_error(&mut self, error: GraphError) {
+        self.errors.insert(error.target.clone(), error);
+    }
+
+    /// Clear error for a specific target.
+    pub fn clear_error(&mut self, target: &ErrorTarget) {
+        self.errors.remove(target);
+    }
+
+    /// Clear all errors.
+    pub fn clear_all_errors(&mut self) {
+        self.errors.clear();
+    }
+
+    /// Clear all execution errors (before running execute()).
+    pub fn clear_execution_errors(&mut self) {
+        self.errors.retain(|_, e| !e.is_execution_error());
+    }
 }
 
 #[cfg(test)]

--- a/src/node_graph/mod.rs
+++ b/src/node_graph/mod.rs
@@ -22,6 +22,8 @@ pub struct NodeGraph {
     dirty_nodes: HashSet<NodeId>,
     /// Current errors in the graph, keyed by target.
     errors: HashMap<ErrorTarget, GraphError>,
+    /// Nodes removed since last execute(). Drained by execute() into GraphChanges.removed_nodes.
+    removed_since_last_execute: Vec<NodeId>,
 }
 
 impl NodeGraph {
@@ -37,6 +39,7 @@ impl NodeGraph {
             cache: Default::default(),
             dirty_nodes: Default::default(),
             errors: Default::default(),
+            removed_since_last_execute: Vec::new(),
         })
     }
 

--- a/src/node_graph/mod.rs
+++ b/src/node_graph/mod.rs
@@ -9,12 +9,15 @@ pub use node_graph_api::*;
 pub use node_manager::*;
 pub use node_state::*;
 
-use crate::{ErrorTarget, GraphError, NodeId};
+use crate::{ErrorTarget, GraphError, NodeId, NodeStatesAccess};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 pub struct NodeGraph {
     node_manager: NodeManager,
-    node_states: SharedNodeStates,
+    /// External state access (for UI integration).
+    /// If None, uses internal state access.
+    state_access: Arc<dyn NodeStatesAccess>,
     cache: SharedExecutionCache,
     dirty_nodes: HashSet<NodeId>,
     /// Current errors in the graph, keyed by target.
@@ -22,12 +25,26 @@ pub struct NodeGraph {
 }
 
 impl NodeGraph {
-    /// Get shared node states (for sync UI access).
+    /// Create a new NodeGraph with external state access.
     ///
-    /// This returns a clone of the Arc, allowing external code
-    /// to access node states without holding the graph lock.
-    pub fn shared_node_states(&self) -> SharedNodeStates {
-        self.node_states.share()
+    /// This is the preferred way to create a NodeGraph when integrating
+    /// with a UI framework like revion. The state access adapter handles
+    /// state updates and can trigger UI rebuilds.
+    pub fn with_state_access(state_access: Arc<dyn NodeStatesAccess>) -> Result<Self, String> {
+        Ok(Self {
+            node_manager: NodeManager::new()?,
+            state_access,
+            cache: Default::default(),
+            dirty_nodes: Default::default(),
+            errors: Default::default(),
+        })
+    }
+
+    /// Get the state access for reading node states.
+    ///
+    /// This provides read-only access to node states through the trait.
+    pub fn state_access(&self) -> &Arc<dyn NodeStatesAccess> {
+        &self.state_access
     }
 
     /// Get shared execution cache (for UI access to output values).

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -10,7 +10,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use crate::{
     node_graph_system::NodeGraphSystem, Data, Edge, EdgeId, GraphError, InternalStateAccess,
-    NodeEntity, NodeGraph, NodeId, NodeImpl, NodeManager, NodeMeta,
+    NodeEntity, NodeGraph, NodeId, NodeImpl, NodeManager, NodeMeta, SubGraphNode,
 };
 
 /// Execution event for progress tracking during graph execution.
@@ -178,17 +178,30 @@ impl NodeGraphAPI for NodeGraph {
                                     Err(_) => return (node_id, Err("Lock poisoned".to_string())),
                                 };
                                 if let Some(node) = nodes_guard.get(&node_id) {
-                                    let node_read = match node.read() {
-                                        Ok(r) => r,
-                                        Err(_) => {
-                                            return (node_id, Err("Node lock poisoned".to_string()))
-                                        }
-                                    };
-                                    // Drop the locks before async execution
                                     let node_clone = Arc::clone(node);
-                                    drop(node_read);
                                     drop(nodes_guard);
-                                    // Re-acquire for execution
+                                    // Try SubGraphNode with write lock (needs &mut for internal graph execution)
+                                    {
+                                        let mut node_write = match node_clone.write() {
+                                            Ok(w) => w,
+                                            Err(_) => {
+                                                return (
+                                                    node_id,
+                                                    Err("Node lock poisoned".to_string()),
+                                                )
+                                            }
+                                        };
+                                        if let Some(sg) = node_write
+                                            .as_any_mut()
+                                            .downcast_mut::<SubGraphNode>()
+                                        {
+                                            return (
+                                                node_id,
+                                                sg.execute_internal(shared_cache.share()).await,
+                                            );
+                                        }
+                                    }
+                                    // Regular node with read lock
                                     let node_read = match node_clone.read() {
                                         Ok(r) => r,
                                         Err(_) => {
@@ -244,16 +257,60 @@ impl NodeGraphAPI for NodeGraph {
                                     };
                                     if let Some(node) = nodes_guard.get(&node_id) {
                                         let node_clone = Arc::clone(node);
+                                        let cache_clone = shared_cache.share();
+                                        let rt_clone = Arc::clone(&rt_handle);
                                         drop(nodes_guard);
-                                        rt_handle.block_on(async {
-                                            let node_read = match node_clone.read() {
-                                                Ok(r) => r,
-                                                Err(_) => {
-                                                    return Err("Node lock poisoned".to_string())
-                                                }
-                                            };
-                                            node_read.execute(shared_cache.share()).await
-                                        })
+                                        // Catch panics so a single node failure
+                                        // doesn't abort the entire execution level.
+                                        match std::panic::catch_unwind(
+                                            std::panic::AssertUnwindSafe(|| {
+                                                rt_clone.block_on(async {
+                                                    // Try SubGraphNode with write lock
+                                                    // (needs &mut for internal graph execution)
+                                                    {
+                                                        let mut node_write =
+                                                            match node_clone.write() {
+                                                                Ok(w) => w,
+                                                                Err(poisoned) => {
+                                                                    poisoned.into_inner()
+                                                                }
+                                                            };
+                                                        if let Some(sg) = node_write
+                                                            .as_any_mut()
+                                                            .downcast_mut::<SubGraphNode>()
+                                                        {
+                                                            return sg
+                                                                .execute_internal(cache_clone)
+                                                                .await;
+                                                        }
+                                                    }
+                                                    // Regular node with read lock.
+                                                    // Recover from poisoned locks (caused by
+                                                    // a previous panic in this node).
+                                                    let node_read = match node_clone.read() {
+                                                        Ok(r) => r,
+                                                        Err(poisoned) => poisoned.into_inner(),
+                                                    };
+                                                    node_read.execute(cache_clone).await
+                                                })
+                                            }),
+                                        ) {
+                                            Ok(result) => result,
+                                            Err(panic_payload) => {
+                                                let msg = if let Some(s) =
+                                                    panic_payload.downcast_ref::<&str>()
+                                                {
+                                                    format!("Node panicked: {}", s)
+                                                } else if let Some(s) =
+                                                    panic_payload.downcast_ref::<String>()
+                                                {
+                                                    format!("Node panicked: {}", s)
+                                                } else {
+                                                    "Node panicked".to_string()
+                                                };
+                                                Err(msg)
+                                            }
+                                        }
                                     } else {
                                         Ok(())
                                     }

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -288,7 +288,7 @@ impl NodeGraphAPI for NodeGraph {
             if let Some(node) = self.node_manager.get_node_by_id(node_id) {
                 if let Ok(read_node) = node.read() {
                     for (idx, slot) in read_node.outputs().iter().enumerate() {
-                        if let Ok(cache) = shared_cache.lock() {
+                        if let Ok(cache) = shared_cache.read() {
                             if let Some(data) = cache.outputs.get(&slot.id) {
                                 outputs.push(NodeOutput {
                                     node_id: *node_id,
@@ -472,7 +472,7 @@ impl NodeGraphAPI for NodeGraph {
         let read_node = node.read().ok()?;
         let slot = read_node.outputs().get(output_slot_index)?;
 
-        let cache = self.cache.lock().ok()?;
+        let cache = self.cache.read().ok()?;
         cache.outputs.get(&slot.id).map(|data| data.share())
     }
 

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -13,53 +13,58 @@ use crate::{
     NodeEntity, NodeGraph, NodeId, NodeImpl, NodeManager, NodeMeta,
 };
 
+/// Execution event for progress tracking during graph execution.
+#[derive(Debug, Clone)]
+pub enum ExecutionEvent {
+    /// Node execution started.
+    Started(NodeId),
+    /// Node execution completed successfully.
+    Completed(NodeId),
+    /// Node execution failed with an error.
+    Failed(NodeId, String),
+}
+
 #[async_trait]
 pub trait NodeGraphAPI {
     fn new() -> Result<Self, String>
     where
         Self: Sized;
 
+    /// Execute the graph asynchronously.
     async fn execute(&mut self) -> Result<(), String>;
 
-    async fn create_node<T: NodeImpl + NodeMeta + 'static>(&mut self) -> Result<NodeId, String>;
-
-    /// Create a node by name (runtime dispatch).
+    /// Execute the graph with progress callback.
     ///
-    /// This allows creating nodes without knowing the concrete type at compile time.
-    /// The node type must be registered via `register_nodes!` macro.
-    async fn create_node_by_name(&mut self, name: &str) -> Result<NodeId, String>;
+    /// The callback is called for each node as it starts executing,
+    /// completes, or fails. This enables real-time UI updates.
+    async fn execute_with_progress<F>(&mut self, on_progress: F) -> Result<(), String>
+    where
+        F: Fn(ExecutionEvent) + Send + Sync + 'static;
 
-    async fn remove_node(&mut self, node_id: NodeId) -> Result<(), String>;
-
-    async fn update_node_data(&mut self, node_id: &NodeId, data: Data) -> Result<(), String>;
-
-    async fn update_input_slot_default_data(
+    // Sync methods for graph structure operations
+    fn create_node<T: NodeImpl + NodeMeta + 'static>(&mut self) -> Result<NodeId, String>;
+    fn create_node_by_name(&mut self, name: &str) -> Result<NodeId, String>;
+    fn remove_node(&mut self, node_id: NodeId) -> Result<(), String>;
+    fn update_node_data(&mut self, node_id: &NodeId, data: Data) -> Result<(), String>;
+    fn update_input_slot_default_data(
         &mut self,
         node_id: &NodeId,
         slot_index: usize,
         data: Data,
     ) -> Result<(), String>;
-
-    async fn get_node_by_id(&self, node_id: &NodeId) -> Option<NodeEntity>;
-
-    async fn get_node_ids_by_type<T: NodeImpl + 'static>(&self) -> Vec<NodeId>;
-
-    async fn get_nodes_by_ids(&self, ids: Vec<NodeId>) -> Vec<(NodeId, NodeEntity)>;
-
-    async fn connect_nodes(
+    fn get_node_by_id(&self, node_id: &NodeId) -> Option<NodeEntity>;
+    fn get_node_ids_by_type<T: NodeImpl + 'static>(&self) -> Vec<NodeId>;
+    fn get_nodes_by_ids(&self, ids: Vec<NodeId>) -> Vec<(NodeId, NodeEntity)>;
+    fn connect_nodes(
         &mut self,
         from_node_id: &NodeId,
         from_output_slot_index: usize,
         to_node_id: &NodeId,
         to_input_slot_index: usize,
     ) -> Result<EdgeId, String>;
-
-    async fn remove_edge(&mut self, edge_id: EdgeId) -> Result<(), String>;
-
+    fn remove_edge(&mut self, edge_id: EdgeId) -> Result<(), String>;
     fn get_edge(&self, edge_id: EdgeId) -> Result<Edge, String>;
-
-    async fn get_output_value(&self, node_id: &NodeId, output_slot_index: usize) -> Option<Data>;
-
+    fn get_output_value(&self, node_id: &NodeId, output_slot_index: usize) -> Option<Data>;
     fn node_variants(&self) -> &HashSet<String>;
 }
 
@@ -76,6 +81,13 @@ impl NodeGraphAPI for NodeGraph {
     }
 
     async fn execute(&mut self) -> Result<(), String> {
+        self.execute_with_progress(|_| {}).await
+    }
+
+    async fn execute_with_progress<F>(&mut self, on_progress: F) -> Result<(), String>
+    where
+        F: Fn(ExecutionEvent) + Send + Sync + 'static,
+    {
         if self.dirty_nodes.is_empty() {
             return Ok(());
         }
@@ -87,23 +99,56 @@ impl NodeGraphAPI for NodeGraph {
 
         let shared_nodes = self.node_manager.nodes();
         let shared_cache = self.cache.share();
+        let on_progress = Arc::new(on_progress);
 
         #[cfg(target_arch = "wasm32")]
         {
             for level_nodes in sorted_node_levels {
                 let futures: Vec<_> = level_nodes
-                    .into_par_iter()
+                    .into_iter()
                     .map(|node_id| {
                         let shared_nodes = shared_nodes.share();
                         let shared_cache = shared_cache.share();
+                        let on_progress = Arc::clone(&on_progress);
                         async move {
-                            let nodes = shared_nodes.lock().await;
-                            let result = if let Some(node) = nodes.get(&node_id) {
-                                let node_read = node.read().await;
-                                node_read.execute(shared_cache.share()).await
-                            } else {
-                                Ok(())
+                            on_progress(ExecutionEvent::Started(node_id));
+
+                            let result = {
+                                let nodes_guard = match shared_nodes.lock() {
+                                    Ok(g) => g,
+                                    Err(_) => return (node_id, Err("Lock poisoned".to_string())),
+                                };
+                                if let Some(node) = nodes_guard.get(&node_id) {
+                                    let node_read = match node.read() {
+                                        Ok(r) => r,
+                                        Err(_) => {
+                                            return (node_id, Err("Node lock poisoned".to_string()))
+                                        }
+                                    };
+                                    // Drop the locks before async execution
+                                    let node_clone = Arc::clone(node);
+                                    drop(node_read);
+                                    drop(nodes_guard);
+                                    // Re-acquire for execution
+                                    let node_read = match node_clone.read() {
+                                        Ok(r) => r,
+                                        Err(_) => {
+                                            return (node_id, Err("Node lock poisoned".to_string()))
+                                        }
+                                    };
+                                    node_read.execute(shared_cache.share()).await
+                                } else {
+                                    Ok(())
+                                }
                             };
+
+                            match &result {
+                                Ok(()) => on_progress(ExecutionEvent::Completed(node_id)),
+                                Err(msg) => {
+                                    on_progress(ExecutionEvent::Failed(node_id, msg.clone()))
+                                }
+                            }
+
                             (node_id, result)
                         }
                     })
@@ -126,19 +171,42 @@ impl NodeGraphAPI for NodeGraph {
                     let shared_nodes = shared_nodes.share();
                     let shared_cache = shared_cache.share();
                     let rt_handle = Arc::clone(&rt_handle);
+                    let on_progress = Arc::clone(&on_progress);
                     move || {
                         level_nodes
                             .into_par_iter()
                             .map(|node_id| {
-                                let result = rt_handle.block_on(async {
-                                    let nodes = shared_nodes.lock().await;
-                                    if let Some(node) = nodes.get(&node_id) {
-                                        let node_read = node.read().await;
-                                        node_read.execute(shared_cache.share()).await
+                                on_progress(ExecutionEvent::Started(node_id));
+
+                                let result = {
+                                    let nodes_guard = match shared_nodes.lock() {
+                                        Ok(g) => g,
+                                        Err(_) => return (node_id, Err("Lock poisoned".to_string())),
+                                    };
+                                    if let Some(node) = nodes_guard.get(&node_id) {
+                                        let node_clone = Arc::clone(node);
+                                        drop(nodes_guard);
+                                        rt_handle.block_on(async {
+                                            let node_read = match node_clone.read() {
+                                                Ok(r) => r,
+                                                Err(_) => {
+                                                    return Err("Node lock poisoned".to_string())
+                                                }
+                                            };
+                                            node_read.execute(shared_cache.share()).await
+                                        })
                                     } else {
                                         Ok(())
                                     }
-                                });
+                                };
+
+                                match &result {
+                                    Ok(()) => on_progress(ExecutionEvent::Completed(node_id)),
+                                    Err(msg) => {
+                                        on_progress(ExecutionEvent::Failed(node_id, msg.clone()))
+                                    }
+                                }
+
                                 (node_id, result)
                             })
                             .collect()
@@ -159,8 +227,8 @@ impl NodeGraphAPI for NodeGraph {
         Ok(())
     }
 
-    async fn create_node<T: NodeImpl + NodeMeta + 'static>(&mut self) -> Result<NodeId, String> {
-        let node_id = self.node_manager.create_node::<T>().await?;
+    fn create_node<T: NodeImpl + NodeMeta + 'static>(&mut self) -> Result<NodeId, String> {
+        let node_id = self.node_manager.create_node::<T>()?;
 
         // Register in NodeStates via state access
         self.state_access.add_node(
@@ -174,9 +242,9 @@ impl NodeGraphAPI for NodeGraph {
         Ok(node_id)
     }
 
-    async fn create_node_by_name(&mut self, name: &str) -> Result<NodeId, String> {
+    fn create_node_by_name(&mut self, name: &str) -> Result<NodeId, String> {
         // Create node and get default data from factory
-        let (node_id, default_data) = self.node_manager.create_node_by_name(name).await?;
+        let (node_id, default_data) = self.node_manager.create_node_by_name(name)?;
 
         // Get type info for slot counts
         let type_info = crate::get_node_type_info(name)
@@ -194,8 +262,8 @@ impl NodeGraphAPI for NodeGraph {
         Ok(node_id)
     }
 
-    async fn remove_node(&mut self, node_id: NodeId) -> Result<(), String> {
-        if self.node_manager.node_remove(&node_id).await.is_some() {
+    fn remove_node(&mut self, node_id: NodeId) -> Result<(), String> {
+        if self.node_manager.node_remove(&node_id).is_some() {
             let dirty_nodes = self.collect_dirty_nodes(vec![node_id])?;
             self.remove_edges_from_cache(&node_id)?;
             self.mark_dirty_nodes(dirty_nodes);
@@ -209,13 +277,12 @@ impl NodeGraphAPI for NodeGraph {
         }
     }
 
-    async fn update_node_data(&mut self, node_id: &NodeId, data: Data) -> Result<(), String> {
+    fn update_node_data(&mut self, node_id: &NodeId, data: Data) -> Result<(), String> {
         let node = self
             .node_manager
             .get_node_by_id(node_id)
-            .await
             .ok_or_else(|| format!("Node with ID {:?} not found", node_id))?;
-        let mut write_node = node.write().await;
+        let mut write_node = node.write().map_err(|e| e.to_string())?;
         write_node.set_node_data(data.share())?;
 
         // Update NodeStates via state access
@@ -226,7 +293,7 @@ impl NodeGraphAPI for NodeGraph {
         Ok(())
     }
 
-    async fn update_input_slot_default_data(
+    fn update_input_slot_default_data(
         &mut self,
         node_id: &NodeId,
         slot_index: usize,
@@ -235,16 +302,15 @@ impl NodeGraphAPI for NodeGraph {
         let node = self
             .node_manager
             .get_node_by_id(node_id)
-            .await
             .ok_or_else(|| format!("Node with ID {:?} not found", node_id))?;
-        let mut write_node = node.write().await;
+        let mut write_node = node.write().map_err(|e| e.to_string())?;
         write_node.set_input_slot_default_data(slot_index, data)?;
         let dirty_nodes = self.collect_dirty_nodes(vec![*node_id])?;
         self.mark_dirty_nodes(dirty_nodes);
         Ok(())
     }
 
-    async fn connect_nodes(
+    fn connect_nodes(
         &mut self,
         from_node_id: &NodeId,
         from_output_slot_index: usize,
@@ -258,12 +324,12 @@ impl NodeGraphAPI for NodeGraph {
                 to_node_id,
                 to_input_slot_index,
             )
-            .await?;
+            .map_err(|e| e.to_string())?;
 
-        self.add_edge(edge).await
+        self.add_edge(edge)
     }
 
-    async fn remove_edge(&mut self, edge_id: EdgeId) -> Result<(), String> {
+    fn remove_edge(&mut self, edge_id: EdgeId) -> Result<(), String> {
         let edge = self.remove_edge_from_cache(&edge_id)?;
 
         let from_node_id = edge.from_node_id;
@@ -304,24 +370,21 @@ impl NodeGraphAPI for NodeGraph {
             .ok_or(format!("Edge not found: id {:?}", edge_id))
     }
 
-    async fn get_node_by_id(&self, node_id: &NodeId) -> Option<NodeEntity> {
-        self.node_manager
-            .get_node_by_id(node_id)
-            .await
-            .map(|node| Arc::clone(&node))
+    fn get_node_by_id(&self, node_id: &NodeId) -> Option<NodeEntity> {
+        self.node_manager.get_node_by_id(node_id)
     }
 
-    async fn get_node_ids_by_type<T: NodeImpl + 'static>(&self) -> Vec<NodeId> {
-        self.node_manager.get_node_ids_by_type::<T>().await
+    fn get_node_ids_by_type<T: NodeImpl + 'static>(&self) -> Vec<NodeId> {
+        self.node_manager.get_node_ids_by_type::<T>()
     }
 
-    async fn get_nodes_by_ids(&self, ids: Vec<NodeId>) -> Vec<(NodeId, NodeEntity)> {
-        self.node_manager.get_nodes_by_ids(ids).await
+    fn get_nodes_by_ids(&self, ids: Vec<NodeId>) -> Vec<(NodeId, NodeEntity)> {
+        self.node_manager.get_nodes_by_ids(ids)
     }
 
-    async fn get_output_value(&self, node_id: &NodeId, output_slot_index: usize) -> Option<Data> {
-        let node = self.get_node_by_id(node_id).await?;
-        let read_node = node.read().await;
+    fn get_output_value(&self, node_id: &NodeId, output_slot_index: usize) -> Option<Data> {
+        let node = self.get_node_by_id(node_id)?;
+        let read_node = node.read().ok()?;
         let slot = read_node.outputs().get(output_slot_index)?;
 
         let cache = self.cache.lock().ok()?;

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -24,6 +24,41 @@ pub enum ExecutionEvent {
     Failed(NodeId, String),
 }
 
+/// Output from a single node execution.
+#[derive(Debug, Clone)]
+pub struct NodeOutput {
+    /// The node that produced this output.
+    pub node_id: NodeId,
+    /// Output slot index.
+    pub slot_index: usize,
+    /// The output data (Arc-shared with ExecutionCache for zero-copy).
+    pub data: Data,
+}
+
+/// Changes produced by a graph execution.
+///
+/// Contains all outputs from nodes that were (re)computed, plus any nodes
+/// that were removed since the last execution.
+#[derive(Debug, Clone, Default)]
+pub struct GraphChanges {
+    /// Outputs from nodes computed in this execution (new + updated).
+    pub outputs: Vec<NodeOutput>,
+    /// Nodes removed since the last execute() call.
+    pub removed_nodes: Vec<NodeId>,
+}
+
+impl GraphChanges {
+    /// Create empty changes.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Check if there are no changes.
+    pub fn is_empty(&self) -> bool {
+        self.outputs.is_empty() && self.removed_nodes.is_empty()
+    }
+}
+
 #[async_trait]
 pub trait NodeGraphAPI {
     fn new() -> Result<Self, String>
@@ -31,13 +66,19 @@ pub trait NodeGraphAPI {
         Self: Sized;
 
     /// Execute the graph asynchronously.
-    async fn execute(&mut self) -> Result<(), String>;
+    ///
+    /// Returns `GraphChanges` containing outputs from computed nodes
+    /// and IDs of nodes removed since the last execution.
+    async fn execute(&mut self) -> Result<GraphChanges, String>;
 
     /// Execute the graph with progress callback.
     ///
     /// The callback is called for each node as it starts executing,
     /// completes, or fails. This enables real-time UI updates.
-    async fn execute_with_progress<F>(&mut self, on_progress: F) -> Result<(), String>
+    ///
+    /// Returns `GraphChanges` containing outputs from computed nodes
+    /// and IDs of nodes removed since the last execution.
+    async fn execute_with_progress<F>(&mut self, on_progress: F) -> Result<GraphChanges, String>
     where
         F: Fn(ExecutionEvent) + Send + Sync + 'static;
 
@@ -77,25 +118,43 @@ impl NodeGraphAPI for NodeGraph {
             cache: Default::default(),
             dirty_nodes: Default::default(),
             errors: Default::default(),
+            removed_since_last_execute: Vec::new(),
         })
     }
 
-    async fn execute(&mut self) -> Result<(), String> {
+    async fn execute(&mut self) -> Result<GraphChanges, String> {
         self.execute_with_progress(|_| {}).await
     }
 
-    async fn execute_with_progress<F>(&mut self, on_progress: F) -> Result<(), String>
+    async fn execute_with_progress<F>(&mut self, on_progress: F) -> Result<GraphChanges, String>
     where
         F: Fn(ExecutionEvent) + Send + Sync + 'static,
     {
+        // Drain removed nodes accumulated since last execute
+        let removed = std::mem::take(&mut self.removed_since_last_execute);
+
+        if self.dirty_nodes.is_empty() && removed.is_empty() {
+            return Ok(GraphChanges::empty());
+        }
+
+        // If only removals (no dirty nodes), return just the removed list
         if self.dirty_nodes.is_empty() {
-            return Ok(());
+            return Ok(GraphChanges {
+                outputs: Vec::new(),
+                removed_nodes: removed,
+            });
         }
 
         // Clear previous execution errors before running
         self.clear_execution_errors();
 
         let sorted_node_levels = self.topological_sort(&self.dirty_nodes)?;
+
+        // Collect all node IDs that will be executed (for output collection)
+        let executed_node_ids: Vec<NodeId> = sorted_node_levels
+            .iter()
+            .flat_map(|level| level.iter().copied())
+            .collect();
 
         let shared_nodes = self.node_manager.nodes();
         let shared_cache = self.cache.share();
@@ -223,8 +282,31 @@ impl NodeGraphAPI for NodeGraph {
             }
         }
 
+        // Collect outputs from executed nodes (Arc-shared for zero-copy)
+        let mut outputs = Vec::new();
+        for node_id in &executed_node_ids {
+            if let Some(node) = self.node_manager.get_node_by_id(node_id) {
+                if let Ok(read_node) = node.read() {
+                    for (idx, slot) in read_node.outputs().iter().enumerate() {
+                        if let Ok(cache) = shared_cache.lock() {
+                            if let Some(data) = cache.outputs.get(&slot.id) {
+                                outputs.push(NodeOutput {
+                                    node_id: *node_id,
+                                    slot_index: idx,
+                                    data: data.share(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         self.dirty_nodes.clear();
-        Ok(())
+        Ok(GraphChanges {
+            outputs,
+            removed_nodes: removed,
+        })
     }
 
     fn create_node<T: NodeImpl + NodeMeta + 'static>(&mut self) -> Result<NodeId, String> {
@@ -270,6 +352,9 @@ impl NodeGraphAPI for NodeGraph {
 
             // Clean up NodeStates via state access
             self.state_access.remove_node(node_id);
+
+            // Track removal for GraphChanges in next execute()
+            self.removed_since_last_execute.push(node_id);
 
             Ok(())
         } else {

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -9,8 +9,8 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{collections::HashSet, sync::Arc};
 
 use crate::{
-    node_graph_system::NodeGraphSystem, Data, Edge, EdgeId, GraphError, NodeEntity, NodeGraph,
-    NodeId, NodeImpl, NodeManager, NodeMeta, SharedNodeStates,
+    node_graph_system::NodeGraphSystem, Data, Edge, EdgeId, GraphError, InternalStateAccess,
+    NodeEntity, NodeGraph, NodeId, NodeImpl, NodeManager, NodeMeta,
 };
 
 #[async_trait]
@@ -68,7 +68,7 @@ impl NodeGraphAPI for NodeGraph {
     fn new() -> Result<Self, String> {
         Ok(Self {
             node_manager: NodeManager::new()?,
-            node_states: SharedNodeStates::new(),
+            state_access: Arc::new(InternalStateAccess::new()),
             cache: Default::default(),
             dirty_nodes: Default::default(),
             errors: Default::default(),
@@ -162,17 +162,14 @@ impl NodeGraphAPI for NodeGraph {
     async fn create_node<T: NodeImpl + NodeMeta + 'static>(&mut self) -> Result<NodeId, String> {
         let node_id = self.node_manager.create_node::<T>().await?;
 
-        // Register in NodeStates for sync UI access
-        self.node_states
-            .write()
-            .map_err(|e| e.to_string())?
-            .add_node(
-                node_id,
-                T::NAME,
-                T::DEFAULT_VALUE.to_data(),
-                T::INPUTS.len(),
-                T::OUTPUTS.len(),
-            );
+        // Register in NodeStates via state access
+        self.state_access.add_node(
+            node_id,
+            T::NAME,
+            T::DEFAULT_VALUE.to_data(),
+            T::INPUTS.len(),
+            T::OUTPUTS.len(),
+        );
 
         Ok(node_id)
     }
@@ -185,17 +182,14 @@ impl NodeGraphAPI for NodeGraph {
         let type_info = crate::get_node_type_info(name)
             .ok_or_else(|| format!("NodeTypeInfo not found for '{}'", name))?;
 
-        // Register in NodeStates for sync UI access
-        self.node_states
-            .write()
-            .map_err(|e| e.to_string())?
-            .add_node(
-                node_id,
-                type_info.name,
-                default_data,
-                type_info.inputs.len(),
-                type_info.outputs.len(),
-            );
+        // Register in NodeStates via state access
+        self.state_access.add_node(
+            node_id,
+            type_info.name,
+            default_data,
+            type_info.inputs.len(),
+            type_info.outputs.len(),
+        );
 
         Ok(node_id)
     }
@@ -206,10 +200,8 @@ impl NodeGraphAPI for NodeGraph {
             self.remove_edges_from_cache(&node_id)?;
             self.mark_dirty_nodes(dirty_nodes);
 
-            // Clean up NodeStates
-            if let Ok(mut states) = self.node_states.write() {
-                states.remove_node(&node_id);
-            }
+            // Clean up NodeStates via state access
+            self.state_access.remove_node(node_id);
 
             Ok(())
         } else {
@@ -226,12 +218,8 @@ impl NodeGraphAPI for NodeGraph {
         let mut write_node = node.write().await;
         write_node.set_node_data(data.share())?;
 
-        // Update NodeStates
-        if let Ok(mut states) = self.node_states.write() {
-            if let Some(state) = states.get_mut(node_id) {
-                state.data = Some(data);
-            }
-        }
+        // Update NodeStates via state access
+        self.state_access.update_node_data(*node_id, Some(data));
 
         let dirty_nodes = self.collect_dirty_nodes(vec![*node_id])?;
         self.mark_dirty_nodes(dirty_nodes);
@@ -281,19 +269,24 @@ impl NodeGraphAPI for NodeGraph {
         let from_node_id = edge.from_node_id;
         let to_node_id = edge.to_node_id;
 
-        // Update NodeStates slot connections and remove edge (single source of truth for UI)
-        if let Ok(mut states) = self.node_states.write() {
+        // Update NodeStates slot connections and remove edge via state access
+        {
+            let mut guard = self
+                .state_access
+                .storage()
+                .write()
+                .map_err(|e| e.to_string())?;
             if let Some(slot_state) =
-                states.output_slot_mut(&from_node_id, edge.from_output_slot_index)
+                guard.output_slot_mut(&from_node_id, edge.from_output_slot_index)
             {
                 slot_state.connected_edges.retain(|id| *id != edge_id);
             }
             if let Some(slot_state) =
-                states.input_slot_mut(&to_node_id, edge.to_input_slot_index)
+                guard.input_slot_mut(&to_node_id, edge.to_input_slot_index)
             {
                 slot_state.connected_edges.retain(|id| *id != edge_id);
             }
-            states.remove_edge(&edge_id);
+            guard.remove_edge(&edge_id);
         }
 
         let dirty_nodes = self.collect_dirty_nodes(vec![from_node_id, to_node_id])?;

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -9,8 +9,8 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{collections::HashSet, sync::Arc};
 
 use crate::{
-    node_graph_system::NodeGraphSystem, Data, Edge, EdgeId, NodeEntity, NodeGraph, NodeId,
-    NodeImpl, NodeManager,
+    node_graph_system::NodeGraphSystem, Data, Edge, EdgeId, GraphError, NodeEntity, NodeGraph,
+    NodeId, NodeImpl, NodeManager, NodeMeta, SharedNodeStates,
 };
 
 #[async_trait]
@@ -21,7 +21,13 @@ pub trait NodeGraphAPI {
 
     async fn execute(&mut self) -> Result<(), String>;
 
-    async fn create_node<T: NodeImpl + 'static>(&mut self) -> Result<NodeId, String>;
+    async fn create_node<T: NodeImpl + NodeMeta + 'static>(&mut self) -> Result<NodeId, String>;
+
+    /// Create a node by name (runtime dispatch).
+    ///
+    /// This allows creating nodes without knowing the concrete type at compile time.
+    /// The node type must be registered via `register_nodes!` macro.
+    async fn create_node_by_name(&mut self, name: &str) -> Result<NodeId, String>;
 
     async fn remove_node(&mut self, node_id: NodeId) -> Result<(), String>;
 
@@ -62,8 +68,10 @@ impl NodeGraphAPI for NodeGraph {
     fn new() -> Result<Self, String> {
         Ok(Self {
             node_manager: NodeManager::new()?,
+            node_states: SharedNodeStates::new(),
             cache: Default::default(),
             dirty_nodes: Default::default(),
+            errors: Default::default(),
         })
     }
 
@@ -71,6 +79,9 @@ impl NodeGraphAPI for NodeGraph {
         if self.dirty_nodes.is_empty() {
             return Ok(());
         }
+
+        // Clear previous execution errors before running
+        self.clear_execution_errors();
 
         let sorted_node_levels = self.topological_sort(&self.dirty_nodes)?;
 
@@ -87,19 +98,22 @@ impl NodeGraphAPI for NodeGraph {
                         let shared_cache = shared_cache.share();
                         async move {
                             let nodes = shared_nodes.lock().await;
-                            if let Some(node) = nodes.get(&node_id) {
+                            let result = if let Some(node) = nodes.get(&node_id) {
                                 let node_read = node.read().await;
                                 node_read.execute(shared_cache.share()).await
                             } else {
                                 Ok(())
-                            }
+                            };
+                            (node_id, result)
                         }
                     })
                     .collect();
 
                 let results = join_all(futures).await;
-                for res in results {
-                    res?;
+                for (node_id, res) in results {
+                    if let Err(msg) = res {
+                        self.add_error(GraphError::execution(node_id, msg));
+                    }
                 }
             }
         }
@@ -108,7 +122,7 @@ impl NodeGraphAPI for NodeGraph {
         {
             let rt_handle = Arc::new(Handle::current());
             for level_nodes in sorted_node_levels {
-                let results: Vec<Result<(), String>> = task::spawn_blocking({
+                let results: Vec<(NodeId, Result<(), String>)> = task::spawn_blocking({
                     let shared_nodes = shared_nodes.share();
                     let shared_cache = shared_cache.share();
                     let rt_handle = Arc::clone(&rt_handle);
@@ -116,7 +130,7 @@ impl NodeGraphAPI for NodeGraph {
                         level_nodes
                             .into_par_iter()
                             .map(|node_id| {
-                                rt_handle.block_on(async {
+                                let result = rt_handle.block_on(async {
                                     let nodes = shared_nodes.lock().await;
                                     if let Some(node) = nodes.get(&node_id) {
                                         let node_read = node.read().await;
@@ -124,7 +138,8 @@ impl NodeGraphAPI for NodeGraph {
                                     } else {
                                         Ok(())
                                     }
-                                })
+                                });
+                                (node_id, result)
                             })
                             .collect()
                     }
@@ -132,8 +147,10 @@ impl NodeGraphAPI for NodeGraph {
                 .await
                 .map_err(|e| e.to_string())?;
 
-                for res in results {
-                    res?;
+                for (node_id, res) in results {
+                    if let Err(msg) = res {
+                        self.add_error(GraphError::execution(node_id, msg));
+                    }
                 }
             }
         }
@@ -142,8 +159,45 @@ impl NodeGraphAPI for NodeGraph {
         Ok(())
     }
 
-    async fn create_node<T: NodeImpl + 'static>(&mut self) -> Result<NodeId, String> {
-        self.node_manager.create_node::<T>().await
+    async fn create_node<T: NodeImpl + NodeMeta + 'static>(&mut self) -> Result<NodeId, String> {
+        let node_id = self.node_manager.create_node::<T>().await?;
+
+        // Register in NodeStates for sync UI access
+        self.node_states
+            .write()
+            .map_err(|e| e.to_string())?
+            .add_node(
+                node_id,
+                T::NAME,
+                T::DEFAULT_VALUE.to_data(),
+                T::INPUTS.len(),
+                T::OUTPUTS.len(),
+            );
+
+        Ok(node_id)
+    }
+
+    async fn create_node_by_name(&mut self, name: &str) -> Result<NodeId, String> {
+        // Create node and get default data from factory
+        let (node_id, default_data) = self.node_manager.create_node_by_name(name).await?;
+
+        // Get type info for slot counts
+        let type_info = crate::get_node_type_info(name)
+            .ok_or_else(|| format!("NodeTypeInfo not found for '{}'", name))?;
+
+        // Register in NodeStates for sync UI access
+        self.node_states
+            .write()
+            .map_err(|e| e.to_string())?
+            .add_node(
+                node_id,
+                type_info.name,
+                default_data,
+                type_info.inputs.len(),
+                type_info.outputs.len(),
+            );
+
+        Ok(node_id)
     }
 
     async fn remove_node(&mut self, node_id: NodeId) -> Result<(), String> {
@@ -151,6 +205,12 @@ impl NodeGraphAPI for NodeGraph {
             let dirty_nodes = self.collect_dirty_nodes(vec![node_id])?;
             self.remove_edges_from_cache(&node_id)?;
             self.mark_dirty_nodes(dirty_nodes);
+
+            // Clean up NodeStates
+            if let Ok(mut states) = self.node_states.write() {
+                states.remove_node(&node_id);
+            }
+
             Ok(())
         } else {
             Err("Node not found.".to_string())
@@ -164,7 +224,15 @@ impl NodeGraphAPI for NodeGraph {
             .await
             .ok_or_else(|| format!("Node with ID {:?} not found", node_id))?;
         let mut write_node = node.write().await;
-        write_node.set_node_data(data)?;
+        write_node.set_node_data(data.share())?;
+
+        // Update NodeStates
+        if let Ok(mut states) = self.node_states.write() {
+            if let Some(state) = states.get_mut(node_id) {
+                state.data = Some(data);
+            }
+        }
+
         let dirty_nodes = self.collect_dirty_nodes(vec![*node_id])?;
         self.mark_dirty_nodes(dirty_nodes);
         Ok(())
@@ -213,19 +281,19 @@ impl NodeGraphAPI for NodeGraph {
         let from_node_id = edge.from_node_id;
         let to_node_id = edge.to_node_id;
 
-        if let Some(node) = self.node_manager.get_node_by_id(&from_node_id).await {
-            let mut node_write = node.write().await;
-            if let Some(slot) = node_write.get_output_slot_by_index_mut(edge.from_output_slot_index)
+        // Update NodeStates slot connections and remove edge (single source of truth for UI)
+        if let Ok(mut states) = self.node_states.write() {
+            if let Some(slot_state) =
+                states.output_slot_mut(&from_node_id, edge.from_output_slot_index)
             {
-                slot.connected_edges.retain(|id| *id != edge_id);
+                slot_state.connected_edges.retain(|id| *id != edge_id);
             }
-        }
-
-        if let Some(node) = self.node_manager.get_node_by_id(&to_node_id).await {
-            let mut node_write = node.write().await;
-            if let Some(slot) = node_write.get_input_slot_by_index_mut(edge.to_input_slot_index) {
-                slot.connected_edges.retain(|id| *id != edge_id);
+            if let Some(slot_state) =
+                states.input_slot_mut(&to_node_id, edge.to_input_slot_index)
+            {
+                slot_state.connected_edges.retain(|id| *id != edge_id);
             }
+            states.remove_edge(&edge_id);
         }
 
         let dirty_nodes = self.collect_dirty_nodes(vec![from_node_id, to_node_id])?;

--- a/src/node_graph/node_graph_system.rs
+++ b/src/node_graph/node_graph_system.rs
@@ -222,7 +222,8 @@ impl NodeGraphSystem for NodeGraph {
         // Check max_connections limit BEFORE adding the edge
         if let Some(max) = to_slot.max_connections() {
             let current_count = self
-                .node_states
+                .state_access
+                .storage()
                 .read()
                 .ok()
                 .map(|s| {
@@ -245,19 +246,24 @@ impl NodeGraphSystem for NodeGraph {
 
         let edge_id = EdgeId::new();
 
-        // Update NodeStates slot connections and add edge (single source of truth for UI)
-        if let Ok(mut states) = self.node_states.write() {
+        // Update NodeStates slot connections and add edge via state access
+        {
+            let mut guard = self
+                .state_access
+                .storage()
+                .write()
+                .map_err(|e| e.to_string())?;
             if let Some(slot_state) =
-                states.output_slot_mut(&from_node_id, edge.from_output_slot_index)
+                guard.output_slot_mut(&from_node_id, edge.from_output_slot_index)
             {
                 slot_state.connected_edges.push(edge_id);
             }
             if let Some(slot_state) =
-                states.input_slot_mut(&to_node_id, edge.to_input_slot_index)
+                guard.input_slot_mut(&to_node_id, edge.to_input_slot_index)
             {
                 slot_state.connected_edges.push(edge_id);
             }
-            states.add_edge(edge_id, edge.clone());
+            guard.add_edge(edge_id, edge.clone());
         }
 
         tracing::debug!("[cognet] add_edge: collecting dirty nodes...");

--- a/src/node_graph/node_graph_system.rs
+++ b/src/node_graph/node_graph_system.rs
@@ -1,4 +1,4 @@
-use crate::{Edge, EdgeId, EntityId, NodeGraph, NodeGraphAPI, NodeId};
+use crate::{Edge, EdgeId, ErrorTarget, GraphError, NodeGraph, NodeGraphAPI, NodeId};
 use std::collections::{HashMap, HashSet, VecDeque};
 
 pub(crate) trait NodeGraphSystem {
@@ -94,12 +94,17 @@ impl NodeGraphSystem for NodeGraph {
         to_node_id: &NodeId,
         to_input_slot_index: usize,
     ) -> Result<Edge, &'static str> {
+        tracing::debug!("[cognet] create_edge: START");
+
         let from_output_slot_id = {
+            tracing::debug!("[cognet] create_edge: getting from_node...");
             let node = self
                 .get_node_by_id(from_node_id)
                 .await
                 .ok_or("From node not found")?;
+            tracing::debug!("[cognet] create_edge: got from_node, acquiring read lock...");
             let read_node = node.read().await;
+            tracing::debug!("[cognet] create_edge: from_node read lock acquired");
             read_node
                 .outputs()
                 .get(from_output_slot_index)
@@ -109,11 +114,14 @@ impl NodeGraphSystem for NodeGraph {
         };
 
         let to_input_slot_id = {
+            tracing::debug!("[cognet] create_edge: getting to_node...");
             let node = self
                 .get_node_by_id(to_node_id)
                 .await
                 .ok_or("To node not found")?;
+            tracing::debug!("[cognet] create_edge: got to_node, acquiring read lock...");
             let read_node = node.read().await;
+            tracing::debug!("[cognet] create_edge: to_node read lock acquired");
             read_node
                 .inputs()
                 .get(to_input_slot_index)
@@ -122,6 +130,7 @@ impl NodeGraphSystem for NodeGraph {
                 .clone()
         };
 
+        tracing::debug!("[cognet] create_edge: DONE");
         Ok(Edge {
             from_node_id: *from_node_id,
             from_output_slot_index,
@@ -133,73 +142,132 @@ impl NodeGraphSystem for NodeGraph {
     }
 
     async fn add_edge(&mut self, edge: Edge) -> Result<EdgeId, String> {
+        tracing::debug!("[cognet] add_edge: START");
         let from_node_id = edge.from_node_id;
         let to_node_id = edge.to_node_id;
 
-        let from_node = self
-            .node_manager
-            .get_node_by_id(&from_node_id)
-            .await
-            .ok_or_else(|| format!("From node {:?} does not exist", edge.from_node_id))?;
-        let to_node = self
-            .node_manager
-            .get_node_by_id(&to_node_id)
-            .await
-            .ok_or_else(|| format!("To node {:?} does not exist", edge.to_node_id))?;
+        // Clear previous errors for the target input port
+        let input_target = ErrorTarget::InputPort {
+            node_id: to_node_id,
+            slot_index: edge.to_input_slot_index,
+        };
+        self.clear_error(&input_target);
 
-        let mut write_from_node = from_node.write().await;
-        let from_slot = write_from_node
-            .get_output_slot_by_index(edge.from_output_slot_index)
-            .ok_or_else(|| {
-                format!(
-                    "Output slot index {:?} does not exist in node {:?}",
-                    edge.from_output_slot_index, edge.from_node_id
-                )
-            })?;
+        tracing::debug!("[cognet] add_edge: getting from_node...");
+        let from_node = match self.node_manager.get_node_by_id(&from_node_id).await {
+            Some(node) => node,
+            None => {
+                let error = GraphError::node_not_found(from_node_id);
+                let msg = error.message();
+                self.add_error(error);
+                return Err(msg);
+            }
+        };
+        tracing::debug!("[cognet] add_edge: got from_node");
 
-        let mut write_to_node = to_node.write().await;
-        let to_slot = write_to_node
-            .get_input_slot_by_index(edge.to_input_slot_index)
-            .ok_or_else(|| {
-                format!(
-                    "Input slot index {:?} does not exist in node {:?}",
-                    edge.to_input_slot_index, edge.to_node_id
-                )
-            })?;
+        tracing::debug!("[cognet] add_edge: getting to_node...");
+        let to_node = match self.node_manager.get_node_by_id(&to_node_id).await {
+            Some(node) => node,
+            None => {
+                let error = GraphError::node_not_found(to_node_id);
+                let msg = error.message();
+                self.add_error(error);
+                return Err(msg);
+            }
+        };
+        tracing::debug!("[cognet] add_edge: got to_node");
 
+        tracing::debug!("[cognet] add_edge: acquiring from_node read lock...");
+        let read_from_node = from_node.read().await;
+        tracing::debug!("[cognet] add_edge: from_node read lock acquired");
+        let from_slot = match read_from_node.get_output_slot_by_index(edge.from_output_slot_index)
+        {
+            Some(slot) => slot,
+            None => {
+                let error =
+                    GraphError::output_slot_not_found(from_node_id, edge.from_output_slot_index);
+                let msg = error.message();
+                self.add_error(error);
+                return Err(msg);
+            }
+        };
+
+        tracing::debug!("[cognet] add_edge: acquiring to_node read lock...");
+        let read_to_node = to_node.read().await;
+        tracing::debug!("[cognet] add_edge: to_node read lock acquired");
+        let to_slot = match read_to_node.get_input_slot_by_index(edge.to_input_slot_index) {
+            Some(slot) => slot,
+            None => {
+                let error =
+                    GraphError::input_slot_not_found(to_node_id, edge.to_input_slot_index);
+                let msg = error.message();
+                self.add_error(error);
+                return Err(msg);
+            }
+        };
+
+        // Check type compatibility
         if from_slot.data_type != to_slot.data_type {
-            return Err(format!(
-                "Data type mismatch between output slot index {:?} and input slot index {:?}",
-                edge.from_output_slot_index, edge.to_input_slot_index
-            ));
+            let error = GraphError::type_mismatch(
+                to_node_id,
+                edge.to_input_slot_index,
+                from_slot.data_type,
+                to_slot.data_type,
+            );
+            let msg = error.message();
+            self.add_error(error);
+            return Err(msg);
+        }
+
+        // Check max_connections limit BEFORE adding the edge
+        if let Some(max) = to_slot.max_connections() {
+            let current_count = self
+                .node_states
+                .read()
+                .ok()
+                .map(|s| {
+                    s.input_slot(&to_node_id, edge.to_input_slot_index)
+                        .map(|slot| slot.connected_edges.len())
+                        .unwrap_or(0)
+                })
+                .unwrap_or(0);
+            if current_count >= *max {
+                let error = GraphError::connection_limit_exceeded(
+                    to_node_id,
+                    edge.to_input_slot_index,
+                    *max,
+                );
+                let msg = error.message();
+                self.add_error(error);
+                return Err(msg);
+            }
         }
 
         let edge_id = EdgeId::new();
 
-        if let Some(slot) =
-            write_from_node.get_output_slot_by_index_mut(edge.from_output_slot_index)
-        {
-            slot.connected_edges.push(edge_id);
-        }
-
-        if let Some(slot) = write_to_node.get_input_slot_by_index_mut(edge.to_input_slot_index) {
-            if let Some(max) = slot.max_connections() {
-                if slot.connected_edges.len() >= *max {
-                    return Err(format!(
-                        "Input slot index {:?} in node: {} reached maximum connection limit ({})",
-                        edge.to_input_slot_index,
-                        edge.to_node_id.id_string(),
-                        max
-                    ));
-                }
+        // Update NodeStates slot connections and add edge (single source of truth for UI)
+        if let Ok(mut states) = self.node_states.write() {
+            if let Some(slot_state) =
+                states.output_slot_mut(&from_node_id, edge.from_output_slot_index)
+            {
+                slot_state.connected_edges.push(edge_id);
             }
-            slot.connected_edges.push(edge_id);
+            if let Some(slot_state) =
+                states.input_slot_mut(&to_node_id, edge.to_input_slot_index)
+            {
+                slot_state.connected_edges.push(edge_id);
+            }
+            states.add_edge(edge_id, edge.clone());
         }
 
+        tracing::debug!("[cognet] add_edge: collecting dirty nodes...");
         let dirty_nodes = self.collect_dirty_nodes(vec![from_node_id, to_node_id])?;
+        tracing::debug!("[cognet] add_edge: marking dirty nodes...");
         self.mark_dirty_nodes(dirty_nodes);
+        tracing::debug!("[cognet] add_edge: acquiring cache lock...");
         let mut cache = self.cache.lock()?;
-        cache.edges.insert(edge_id, edge);
+        cache.add_edge(edge_id, edge);
+        tracing::debug!("[cognet] add_edge: DONE");
 
         Ok(edge_id)
     }
@@ -234,8 +302,7 @@ impl NodeGraphSystem for NodeGraph {
     fn remove_edge_from_cache(&self, edge_id: &EdgeId) -> Result<Edge, String> {
         let mut cache = self.cache.lock()?;
         cache
-            .edges
-            .remove(edge_id)
+            .remove_edge(edge_id)
             .ok_or(format!("Edge does not exist: id: {:?}", edge_id))
     }
 

--- a/src/node_graph/node_graph_system.rs
+++ b/src/node_graph/node_graph_system.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 pub(crate) trait NodeGraphSystem {
     fn topological_sort(&self, target_nodes: &HashSet<NodeId>) -> Result<Vec<Vec<NodeId>>, String>;
 
-    async fn create_edge(
+    fn create_edge(
         &self,
         from_node_id: &NodeId,
         from_output_slot_index: usize,
@@ -12,7 +12,7 @@ pub(crate) trait NodeGraphSystem {
         to_input_slot_index: usize,
     ) -> Result<Edge, &'static str>;
 
-    async fn add_edge(&mut self, edge: Edge) -> Result<EdgeId, String>;
+    fn add_edge(&mut self, edge: Edge) -> Result<EdgeId, String>;
 
     fn collect_dirty_nodes(&self, initial_nodes: Vec<NodeId>) -> Result<Vec<NodeId>, String>;
 
@@ -87,7 +87,7 @@ impl NodeGraphSystem for NodeGraph {
         Ok(sorted)
     }
 
-    async fn create_edge(
+    fn create_edge(
         &self,
         from_node_id: &NodeId,
         from_output_slot_index: usize,
@@ -100,10 +100,9 @@ impl NodeGraphSystem for NodeGraph {
             tracing::debug!("[cognet] create_edge: getting from_node...");
             let node = self
                 .get_node_by_id(from_node_id)
-                .await
                 .ok_or("From node not found")?;
             tracing::debug!("[cognet] create_edge: got from_node, acquiring read lock...");
-            let read_node = node.read().await;
+            let read_node = node.read().map_err(|_| "Failed to acquire read lock")?;
             tracing::debug!("[cognet] create_edge: from_node read lock acquired");
             read_node
                 .outputs()
@@ -117,10 +116,9 @@ impl NodeGraphSystem for NodeGraph {
             tracing::debug!("[cognet] create_edge: getting to_node...");
             let node = self
                 .get_node_by_id(to_node_id)
-                .await
                 .ok_or("To node not found")?;
             tracing::debug!("[cognet] create_edge: got to_node, acquiring read lock...");
-            let read_node = node.read().await;
+            let read_node = node.read().map_err(|_| "Failed to acquire read lock")?;
             tracing::debug!("[cognet] create_edge: to_node read lock acquired");
             read_node
                 .inputs()
@@ -141,7 +139,7 @@ impl NodeGraphSystem for NodeGraph {
         })
     }
 
-    async fn add_edge(&mut self, edge: Edge) -> Result<EdgeId, String> {
+    fn add_edge(&mut self, edge: Edge) -> Result<EdgeId, String> {
         tracing::debug!("[cognet] add_edge: START");
         let from_node_id = edge.from_node_id;
         let to_node_id = edge.to_node_id;
@@ -154,7 +152,7 @@ impl NodeGraphSystem for NodeGraph {
         self.clear_error(&input_target);
 
         tracing::debug!("[cognet] add_edge: getting from_node...");
-        let from_node = match self.node_manager.get_node_by_id(&from_node_id).await {
+        let from_node = match self.node_manager.get_node_by_id(&from_node_id) {
             Some(node) => node,
             None => {
                 let error = GraphError::node_not_found(from_node_id);
@@ -166,7 +164,7 @@ impl NodeGraphSystem for NodeGraph {
         tracing::debug!("[cognet] add_edge: got from_node");
 
         tracing::debug!("[cognet] add_edge: getting to_node...");
-        let to_node = match self.node_manager.get_node_by_id(&to_node_id).await {
+        let to_node = match self.node_manager.get_node_by_id(&to_node_id) {
             Some(node) => node,
             None => {
                 let error = GraphError::node_not_found(to_node_id);
@@ -178,7 +176,7 @@ impl NodeGraphSystem for NodeGraph {
         tracing::debug!("[cognet] add_edge: got to_node");
 
         tracing::debug!("[cognet] add_edge: acquiring from_node read lock...");
-        let read_from_node = from_node.read().await;
+        let read_from_node = from_node.read().map_err(|e| e.to_string())?;
         tracing::debug!("[cognet] add_edge: from_node read lock acquired");
         let from_slot = match read_from_node.get_output_slot_by_index(edge.from_output_slot_index)
         {
@@ -193,7 +191,7 @@ impl NodeGraphSystem for NodeGraph {
         };
 
         tracing::debug!("[cognet] add_edge: acquiring to_node read lock...");
-        let read_to_node = to_node.read().await;
+        let read_to_node = to_node.read().map_err(|e| e.to_string())?;
         tracing::debug!("[cognet] add_edge: to_node read lock acquired");
         let to_slot = match read_to_node.get_input_slot_by_index(edge.to_input_slot_index) {
             Some(slot) => slot,
@@ -243,6 +241,10 @@ impl NodeGraphSystem for NodeGraph {
                 return Err(msg);
             }
         }
+
+        // Release the read locks before acquiring write lock
+        drop(read_from_node);
+        drop(read_to_node);
 
         let edge_id = EdgeId::new();
 

--- a/src/node_graph/node_graph_system.rs
+++ b/src/node_graph/node_graph_system.rs
@@ -34,17 +34,20 @@ impl NodeGraphSystem for NodeGraph {
         }
 
         let cache = self.cache.lock()?;
-        for edge in cache.edges.values() {
-            if target_nodes.contains(&edge.from_node_id) && target_nodes.contains(&edge.to_node_id)
-            {
-                in_degree
-                    .entry(&edge.to_node_id)
-                    .and_modify(|count| *count += 1)
-                    .or_insert(1);
-                adj_list
-                    .entry(&edge.from_node_id)
-                    .or_default()
-                    .push(edge.to_node_id);
+        for node_id in target_nodes {
+            for edge_id in cache.outgoing_edges_for_node(node_id) {
+                if let Some(edge) = cache.edges.get(edge_id) {
+                    if target_nodes.contains(&edge.to_node_id) {
+                        in_degree
+                            .entry(&edge.to_node_id)
+                            .and_modify(|count| *count += 1)
+                            .or_insert(1);
+                        adj_list
+                            .entry(&edge.from_node_id)
+                            .or_default()
+                            .push(edge.to_node_id);
+                    }
+                }
             }
         }
 
@@ -288,9 +291,11 @@ impl NodeGraphSystem for NodeGraph {
 
         while let Some(node_id) = queue.pop_front() {
             if affected.insert(node_id) {
-                for edge in cache.edges.values() {
-                    if edge.from_node_id == node_id && !affected.contains(&edge.to_node_id) {
-                        queue.push_back(edge.to_node_id);
+                for edge_id in cache.outgoing_edges_for_node(&node_id) {
+                    if let Some(edge) = cache.edges.get(edge_id) {
+                        if !affected.contains(&edge.to_node_id) {
+                            queue.push_back(edge.to_node_id);
+                        }
                     }
                 }
             }
@@ -301,9 +306,7 @@ impl NodeGraphSystem for NodeGraph {
 
     fn remove_edges_from_cache(&self, node_id: &NodeId) -> Result<(), String> {
         let mut cache = self.cache.lock()?;
-        cache
-            .edges
-            .retain(|_, edge| edge.from_node_id != *node_id && edge.to_node_id != *node_id);
+        cache.remove_edges_for_node(node_id);
         Ok(())
     }
 

--- a/src/node_graph/node_manager.rs
+++ b/src/node_graph/node_manager.rs
@@ -1,8 +1,4 @@
-#[cfg(not(target_arch = "wasm32"))]
-use tokio::sync::{Mutex, MutexGuard, RwLock};
-
-#[cfg(target_arch = "wasm32")]
-use async_lock::{Mutex, MutexGuard, RwLock};
+use std::sync::{Mutex, MutexGuard, RwLock};
 
 use crate::{Data, NodeCore, NodeId, NodeImpl, NodeValueSetter};
 use std::{
@@ -37,8 +33,10 @@ impl SharedNodes {
         }
     }
 
-    pub async fn lock(&self) -> MutexGuard<'_, HashMap<NodeId, NodeEntity>> {
-        self.inner.lock().await
+    /// Lock the nodes map for access.
+    /// Returns an error if the lock is poisoned.
+    pub fn lock(&self) -> Result<MutexGuard<'_, HashMap<NodeId, NodeEntity>>, String> {
+        self.inner.lock().map_err(|e| e.to_string())
     }
 
     pub fn share(&self) -> Self {
@@ -78,21 +76,27 @@ impl NodeManager {
         self.nodes.share()
     }
 
-    pub async fn get_node_by_id(&self, id: &NodeId) -> Option<NodeEntity> {
-        let nodes = self.nodes.lock().await;
+    pub fn get_node_by_id(&self, id: &NodeId) -> Option<NodeEntity> {
+        let nodes = self.nodes.lock().ok()?;
         nodes.get(id).map(|node| Arc::clone(node))
     }
 
-    pub async fn get_nodes_by_ids(&self, ids: Vec<NodeId>) -> Vec<(NodeId, NodeEntity)> {
-        let nodes = self.nodes.lock().await;
+    pub fn get_nodes_by_ids(&self, ids: Vec<NodeId>) -> Vec<(NodeId, NodeEntity)> {
+        let nodes = match self.nodes.lock() {
+            Ok(n) => n,
+            Err(_) => return Vec::new(),
+        };
 
         ids.into_iter()
             .filter_map(|id| nodes.get(&id).map(|node| (id, Arc::clone(node))))
             .collect()
     }
 
-    pub async fn get_node_ids_by_type<T: NodeImpl + 'static>(&self) -> Vec<NodeId> {
-        let nodes = self.nodes.lock().await;
+    pub fn get_node_ids_by_type<T: NodeImpl + 'static>(&self) -> Vec<NodeId> {
+        let nodes = match self.nodes.lock() {
+            Ok(n) => n,
+            Err(_) => return Vec::new(),
+        };
 
         let mut result: Vec<NodeId> = Vec::new();
 
@@ -105,18 +109,21 @@ impl NodeManager {
         result
     }
 
-    pub async fn contains_key(&self, id: &NodeId) -> bool {
-        let nodes = self.nodes.lock().await;
+    pub fn contains_key(&self, id: &NodeId) -> bool {
+        let nodes = match self.nodes.lock() {
+            Ok(n) => n,
+            Err(_) => return false,
+        };
         nodes.contains_key(id)
     }
 
-    pub async fn node_insert(&self, node_id: NodeId, node: NodeEntity) -> Option<NodeEntity> {
-        let mut nodes = self.nodes.lock().await;
+    pub fn node_insert(&self, node_id: NodeId, node: NodeEntity) -> Option<NodeEntity> {
+        let mut nodes = self.nodes.lock().ok()?;
         nodes.insert(node_id, node)
     }
 
-    pub async fn node_remove(&self, node_id: &NodeId) -> Option<NodeEntity> {
-        let mut nodes = self.nodes.lock().await;
+    pub fn node_remove(&self, node_id: &NodeId) -> Option<NodeEntity> {
+        let mut nodes = self.nodes.lock().ok()?;
         nodes.remove(node_id)
     }
 
@@ -162,11 +169,11 @@ impl NodeManager {
     }
 
     /// Create a node by type (compile-time dispatch).
-    pub async fn create_node<T: NodeImpl + 'static>(&mut self) -> Result<NodeId, String> {
+    pub fn create_node<T: NodeImpl + 'static>(&mut self) -> Result<NodeId, String> {
         if let Some(factory) = self.node_registry.get(&TypeId::of::<T>()) {
             let node = factory()?;
             let node_id = NodeId::new();
-            self.node_insert(node_id, node).await;
+            self.node_insert(node_id, node);
             Ok(node_id)
         } else {
             Err(format!("{:?} is not registered", TypeId::of::<T>()))
@@ -176,7 +183,7 @@ impl NodeManager {
     /// Create a node by name (runtime dispatch).
     ///
     /// Returns the node ID and default data if successful.
-    pub async fn create_node_by_name(
+    pub fn create_node_by_name(
         &self,
         name: &str,
     ) -> Result<(NodeId, Option<Data>), String> {
@@ -188,7 +195,7 @@ impl NodeManager {
         let node = (factory_meta.factory)()?;
         let default_data = factory_meta.default_data.as_ref().map(|d| d.share());
         let node_id = NodeId::new();
-        self.node_insert(node_id, node).await;
+        self.node_insert(node_id, node);
 
         Ok((node_id, default_data))
     }

--- a/src/node_graph/node_manager.rs
+++ b/src/node_graph/node_manager.rs
@@ -34,9 +34,12 @@ impl SharedNodes {
     }
 
     /// Lock the nodes map for access.
-    /// Returns an error if the lock is poisoned.
+    /// Recovers from poisoned locks (caused by panics caught via catch_unwind).
     pub fn lock(&self) -> Result<MutexGuard<'_, HashMap<NodeId, NodeEntity>>, String> {
-        self.inner.lock().map_err(|e| e.to_string())
+        match self.inner.lock() {
+            Ok(guard) => Ok(guard),
+            Err(poisoned) => Ok(poisoned.into_inner()),
+        }
     }
 
     pub fn share(&self) -> Self {
@@ -74,6 +77,14 @@ impl NodeManager {
 
     pub fn nodes(&self) -> SharedNodes {
         self.nodes.share()
+    }
+
+    pub fn all_node_ids(&self) -> Vec<NodeId> {
+        self.nodes
+            .lock()
+            .ok()
+            .map(|nodes| nodes.keys().copied().collect())
+            .unwrap_or_default()
     }
 
     pub fn get_node_by_id(&self, id: &NodeId) -> Option<NodeEntity> {

--- a/src/node_graph/node_manager.rs
+++ b/src/node_graph/node_manager.rs
@@ -4,7 +4,7 @@ use tokio::sync::{Mutex, MutexGuard, RwLock};
 #[cfg(target_arch = "wasm32")]
 use async_lock::{Mutex, MutexGuard, RwLock};
 
-use crate::{NodeCore, NodeId, NodeImpl, NodeValueSetter};
+use crate::{Data, NodeCore, NodeId, NodeImpl, NodeValueSetter};
 use std::{
     any::{type_name, Any, TypeId},
     collections::{HashMap, HashSet},
@@ -16,6 +16,14 @@ impl<T: NodeImpl + NodeValueSetter + NodeCore> Node for T {}
 
 pub type NodeEntity = Arc<RwLock<dyn Node>>;
 type NodeFactory = Arc<dyn Fn() -> Result<NodeEntity, String> + Send + Sync>;
+
+/// Factory with metadata for name-based node creation.
+pub struct NodeFactoryWithMeta {
+    /// The factory function to create the node.
+    pub factory: NodeFactory,
+    /// Default data for the node (if any).
+    pub default_data: Option<Data>,
+}
 
 #[derive(Default, Debug)]
 pub struct SharedNodes {
@@ -29,7 +37,7 @@ impl SharedNodes {
         }
     }
 
-    pub async fn lock(&self) -> MutexGuard<HashMap<NodeId, NodeEntity>> {
+    pub async fn lock(&self) -> MutexGuard<'_, HashMap<NodeId, NodeEntity>> {
         self.inner.lock().await
     }
 
@@ -44,6 +52,8 @@ impl SharedNodes {
 pub struct NodeManager {
     nodes: SharedNodes,
     node_registry: HashMap<TypeId, NodeFactory>,
+    /// Name-based registry for dynamic node creation.
+    name_registry: HashMap<&'static str, NodeFactoryWithMeta>,
     variants: HashSet<String>,
 }
 
@@ -114,6 +124,7 @@ impl NodeManager {
         &self.variants
     }
 
+    /// Register a factory by type.
     pub fn register_factory<T: NodeImpl + 'static>(
         &mut self,
         factory: NodeFactory,
@@ -139,6 +150,18 @@ impl NodeManager {
         }
     }
 
+    /// Register a factory with name and metadata for dynamic creation.
+    pub fn register_factory_with_name(
+        &mut self,
+        name: &'static str,
+        factory: NodeFactory,
+        default_data: Option<Data>,
+    ) {
+        self.name_registry
+            .insert(name, NodeFactoryWithMeta { factory, default_data });
+    }
+
+    /// Create a node by type (compile-time dispatch).
     pub async fn create_node<T: NodeImpl + 'static>(&mut self) -> Result<NodeId, String> {
         if let Some(factory) = self.node_registry.get(&TypeId::of::<T>()) {
             let node = factory()?;
@@ -148,5 +171,35 @@ impl NodeManager {
         } else {
             Err(format!("{:?} is not registered", TypeId::of::<T>()))
         }
+    }
+
+    /// Create a node by name (runtime dispatch).
+    ///
+    /// Returns the node ID and default data if successful.
+    pub async fn create_node_by_name(
+        &self,
+        name: &str,
+    ) -> Result<(NodeId, Option<Data>), String> {
+        let factory_meta = self
+            .name_registry
+            .get(name)
+            .ok_or_else(|| format!("Node type '{}' is not registered", name))?;
+
+        let node = (factory_meta.factory)()?;
+        let default_data = factory_meta.default_data.as_ref().map(|d| d.share());
+        let node_id = NodeId::new();
+        self.node_insert(node_id, node).await;
+
+        Ok((node_id, default_data))
+    }
+
+    /// Check if a node type is registered by name.
+    pub fn is_registered(&self, name: &str) -> bool {
+        self.name_registry.contains_key(name)
+    }
+
+    /// Get all registered node type names.
+    pub fn registered_names(&self) -> Vec<&'static str> {
+        self.name_registry.keys().copied().collect()
     }
 }

--- a/src/node_graph/node_state.rs
+++ b/src/node_graph/node_state.rs
@@ -2,7 +2,6 @@
 
 use crate::{Data, Edge, EdgeId, InputSlotId, NodeId, OutputSlotId};
 use std::collections::HashMap;
-use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// Runtime state for a single node instance.
 #[derive(Debug)]
@@ -172,55 +171,5 @@ impl NodeStates {
             .iter()
             .filter(|(_, e)| &e.from_node_id == node_id || &e.to_node_id == node_id)
             .collect()
-    }
-}
-
-// ============================================================================
-// SharedNodeStates - Thread-safe wrapper for external access
-// ============================================================================
-
-/// Convert a PoisonError to a String error message.
-fn poison_error<T>(err: PoisonError<T>) -> String {
-    format!("Lock poisoned: {}", err)
-}
-
-/// Thread-safe wrapper for NodeStates.
-///
-/// This allows UI code to access node states synchronously without
-/// needing to hold the async graph lock.
-#[derive(Debug, Clone)]
-pub struct SharedNodeStates {
-    inner: Arc<RwLock<NodeStates>>,
-}
-
-impl Default for SharedNodeStates {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SharedNodeStates {
-    /// Create a new shared node states.
-    pub fn new() -> Self {
-        Self {
-            inner: Arc::new(RwLock::new(NodeStates::new())),
-        }
-    }
-
-    /// Get read access to the inner NodeStates.
-    pub fn read(&self) -> Result<RwLockReadGuard<'_, NodeStates>, String> {
-        self.inner.read().map_err(poison_error)
-    }
-
-    /// Get write access to the inner NodeStates.
-    pub fn write(&self) -> Result<RwLockWriteGuard<'_, NodeStates>, String> {
-        self.inner.write().map_err(poison_error)
-    }
-
-    /// Clone the Arc (cheap).
-    pub fn share(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
-        }
     }
 }

--- a/src/node_graph/node_state.rs
+++ b/src/node_graph/node_state.rs
@@ -4,7 +4,7 @@ use crate::{Data, Edge, EdgeId, InputSlotId, NodeId, OutputSlotId};
 use std::collections::HashMap;
 
 /// Runtime state for a single node instance.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NodeState {
     /// The node type name (references NodeMeta::NAME).
     pub type_name: &'static str,
@@ -22,21 +22,21 @@ impl NodeState {
 }
 
 /// Runtime state for input slots.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct InputSlotState {
     pub id: InputSlotId,
     pub connected_edges: Vec<EdgeId>,
 }
 
 /// Runtime state for output slots.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct OutputSlotState {
     pub id: OutputSlotId,
     pub connected_edges: Vec<EdgeId>,
 }
 
 /// Manages all node states in the graph.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct NodeStates {
     /// Node data by NodeId.
     nodes: HashMap<NodeId, NodeState>,

--- a/src/node_graph/node_state.rs
+++ b/src/node_graph/node_state.rs
@@ -1,0 +1,226 @@
+//! Runtime state for node instances.
+
+use crate::{Data, Edge, EdgeId, InputSlotId, NodeId, OutputSlotId};
+use std::collections::HashMap;
+use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// Runtime state for a single node instance.
+#[derive(Debug)]
+pub struct NodeState {
+    /// The node type name (references NodeMeta::NAME).
+    pub type_name: &'static str,
+    /// Current data value (can be modified at runtime).
+    pub data: Option<Data>,
+}
+
+impl NodeState {
+    pub fn new(type_name: &'static str, default_data: Option<Data>) -> Self {
+        Self {
+            type_name,
+            data: default_data,
+        }
+    }
+}
+
+/// Runtime state for input slots.
+#[derive(Debug, Default)]
+pub struct InputSlotState {
+    pub id: InputSlotId,
+    pub connected_edges: Vec<EdgeId>,
+}
+
+/// Runtime state for output slots.
+#[derive(Debug, Default)]
+pub struct OutputSlotState {
+    pub id: OutputSlotId,
+    pub connected_edges: Vec<EdgeId>,
+}
+
+/// Manages all node states in the graph.
+#[derive(Debug, Default)]
+pub struct NodeStates {
+    /// Node data by NodeId.
+    nodes: HashMap<NodeId, NodeState>,
+    /// Input slot states by (NodeId, slot_index).
+    input_slots: HashMap<(NodeId, usize), InputSlotState>,
+    /// Output slot states by (NodeId, slot_index).
+    output_slots: HashMap<(NodeId, usize), OutputSlotState>,
+    /// All edges in the graph.
+    edges: HashMap<EdgeId, Edge>,
+}
+
+impl NodeStates {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a new node.
+    pub fn add_node(
+        &mut self,
+        node_id: NodeId,
+        type_name: &'static str,
+        default_data: Option<Data>,
+        input_count: usize,
+        output_count: usize,
+    ) {
+        self.nodes
+            .insert(node_id, NodeState::new(type_name, default_data));
+
+        // Initialize input slot states
+        for i in 0..input_count {
+            self.input_slots.insert(
+                (node_id, i),
+                InputSlotState {
+                    id: InputSlotId::new(),
+                    connected_edges: Vec::new(),
+                },
+            );
+        }
+
+        // Initialize output slot states
+        for i in 0..output_count {
+            self.output_slots.insert(
+                (node_id, i),
+                OutputSlotState {
+                    id: OutputSlotId::new(),
+                    connected_edges: Vec::new(),
+                },
+            );
+        }
+    }
+
+    /// Remove a node and its slot states.
+    pub fn remove_node(&mut self, node_id: &NodeId) -> Option<NodeState> {
+        // Remove slot states
+        self.input_slots.retain(|(id, _), _| id != node_id);
+        self.output_slots.retain(|(id, _), _| id != node_id);
+
+        self.nodes.remove(node_id)
+    }
+
+    /// Get node state.
+    pub fn get(&self, node_id: &NodeId) -> Option<&NodeState> {
+        self.nodes.get(node_id)
+    }
+
+    /// Get mutable node state.
+    pub fn get_mut(&mut self, node_id: &NodeId) -> Option<&mut NodeState> {
+        self.nodes.get_mut(node_id)
+    }
+
+    /// Get input slot state.
+    pub fn input_slot(&self, node_id: &NodeId, slot_index: usize) -> Option<&InputSlotState> {
+        self.input_slots.get(&(*node_id, slot_index))
+    }
+
+    /// Get mutable input slot state.
+    pub fn input_slot_mut(
+        &mut self,
+        node_id: &NodeId,
+        slot_index: usize,
+    ) -> Option<&mut InputSlotState> {
+        self.input_slots.get_mut(&(*node_id, slot_index))
+    }
+
+    /// Get output slot state.
+    pub fn output_slot(&self, node_id: &NodeId, slot_index: usize) -> Option<&OutputSlotState> {
+        self.output_slots.get(&(*node_id, slot_index))
+    }
+
+    /// Get mutable output slot state.
+    pub fn output_slot_mut(
+        &mut self,
+        node_id: &NodeId,
+        slot_index: usize,
+    ) -> Option<&mut OutputSlotState> {
+        self.output_slots.get_mut(&(*node_id, slot_index))
+    }
+
+    /// Get all node IDs.
+    pub fn node_ids(&self) -> impl Iterator<Item = &NodeId> {
+        self.nodes.keys()
+    }
+
+    /// Get all nodes.
+    pub fn iter(&self) -> impl Iterator<Item = (&NodeId, &NodeState)> {
+        self.nodes.iter()
+    }
+
+    /// Add an edge.
+    pub fn add_edge(&mut self, edge_id: EdgeId, edge: Edge) {
+        self.edges.insert(edge_id, edge);
+    }
+
+    /// Remove an edge.
+    pub fn remove_edge(&mut self, edge_id: &EdgeId) -> Option<Edge> {
+        self.edges.remove(edge_id)
+    }
+
+    /// Get an edge by ID.
+    pub fn get_edge(&self, edge_id: &EdgeId) -> Option<&Edge> {
+        self.edges.get(edge_id)
+    }
+
+    /// Get all edges.
+    pub fn edges(&self) -> &HashMap<EdgeId, Edge> {
+        &self.edges
+    }
+
+    /// Get edges connected to a node.
+    pub fn edges_for_node(&self, node_id: &NodeId) -> Vec<(&EdgeId, &Edge)> {
+        self.edges
+            .iter()
+            .filter(|(_, e)| &e.from_node_id == node_id || &e.to_node_id == node_id)
+            .collect()
+    }
+}
+
+// ============================================================================
+// SharedNodeStates - Thread-safe wrapper for external access
+// ============================================================================
+
+/// Convert a PoisonError to a String error message.
+fn poison_error<T>(err: PoisonError<T>) -> String {
+    format!("Lock poisoned: {}", err)
+}
+
+/// Thread-safe wrapper for NodeStates.
+///
+/// This allows UI code to access node states synchronously without
+/// needing to hold the async graph lock.
+#[derive(Debug, Clone)]
+pub struct SharedNodeStates {
+    inner: Arc<RwLock<NodeStates>>,
+}
+
+impl Default for SharedNodeStates {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SharedNodeStates {
+    /// Create a new shared node states.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(NodeStates::new())),
+        }
+    }
+
+    /// Get read access to the inner NodeStates.
+    pub fn read(&self) -> Result<RwLockReadGuard<'_, NodeStates>, String> {
+        self.inner.read().map_err(poison_error)
+    }
+
+    /// Get write access to the inner NodeStates.
+    pub fn write(&self) -> Result<RwLockWriteGuard<'_, NodeStates>, String> {
+        self.inner.write().map_err(poison_error)
+    }
+
+    /// Clone the Arc (cheap).
+    pub fn share(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}

--- a/src/node_graph/subgraph_ops.rs
+++ b/src/node_graph/subgraph_ops.rs
@@ -1,0 +1,788 @@
+//! SubGraph operations: group_nodes and ungroup_node.
+//!
+//! These operations allow grouping selected nodes into a SubGraphNode
+//! and ungrouping them back into the parent graph.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    DataType, Edge, EdgeId, InputSlot, NodeGraph, NodeGraphAPI, NodeId, OutputSlot, SubGraphNode,
+};
+
+/// Information about an edge crossing the subgraph boundary.
+#[derive(Debug)]
+struct BoundaryEdge {
+    edge_id: EdgeId,
+    edge: Edge,
+}
+
+/// Result of grouping nodes into a subgraph.
+#[derive(Debug)]
+pub struct GroupResult {
+    /// The NodeId of the new SubGraphNode in the parent graph.
+    pub subgraph_node_id: NodeId,
+    /// Mapping from original node IDs to internal node IDs inside the subgraph.
+    /// Used for copying positions when expanding into the subgraph view.
+    pub node_id_remap: HashMap<NodeId, NodeId>,
+}
+
+/// Result of ungrouping a subgraph node.
+#[derive(Debug)]
+pub struct UngroupResult {
+    /// NodeIds of nodes that were extracted from the subgraph back into the parent.
+    pub extracted_node_ids: Vec<NodeId>,
+}
+
+impl NodeGraph {
+    /// Group a set of nodes into a SubGraphNode.
+    ///
+    /// Automatically detects external I/O edges:
+    /// - Edges from outside → selected nodes become SubGraphNode inputs
+    /// - Edges from selected nodes → outside become SubGraphNode outputs
+    /// - Internal edges (both endpoints selected) are preserved inside the subgraph
+    ///
+    /// Returns the NodeId of the newly created SubGraphNode.
+    pub fn group_nodes(
+        &mut self,
+        node_ids: &HashSet<NodeId>,
+        label: impl Into<String>,
+    ) -> Result<GroupResult, String> {
+        if node_ids.is_empty() {
+            return Err("Cannot group empty set of nodes".to_string());
+        }
+
+        // 1. Classify edges into: incoming, outgoing, internal
+        let (incoming_edges, outgoing_edges, internal_edges) =
+            self.classify_boundary_edges(node_ids)?;
+
+        // 2. Filter outgoing boundary edges: skip "intermediate" outputs.
+        //    If an output slot (from_node, from_slot) has BOTH internal consumers
+        //    (edges to selected nodes) AND external consumers (outgoing edges), the
+        //    data already flows through the internal chain. The external connections
+        //    are intermediate taps that clutter the SubGraphNode interface.
+        //    Only expose output ports for slots whose data is exclusively consumed
+        //    externally.
+        //    NOTE: Incoming edges are NOT filtered. Multi-input slots may have both
+        //    external and internal sources, and filtering would remove valid external
+        //    connections.
+        let internal_source_slots: HashSet<(NodeId, usize)> = internal_edges
+            .iter()
+            .map(|e| (e.edge.from_node_id, e.edge.from_output_slot_index))
+            .collect();
+
+        // Keep only outgoing edges whose source slot has NO internal consumers
+        let (outgoing_edges, dropped_outgoing): (Vec<_>, Vec<_>) =
+            outgoing_edges.into_iter().partition(|e| {
+                !internal_source_slots
+                    .contains(&(e.edge.from_node_id, e.edge.from_output_slot_index))
+            });
+
+        // Incoming edges: no filter (all external sources are valid inputs)
+        let dropped_incoming: Vec<BoundaryEdge> = Vec::new();
+
+        // 3. Deduplicate boundary edges by source/target slot.
+        //    Multiple edges from the same output slot share one SubGraphNode port.
+        //    Multiple edges to the same input slot share one SubGraphNode port.
+        let deduped_outgoing = Self::dedup_outgoing(&outgoing_edges);
+        let deduped_incoming = Self::dedup_incoming(&incoming_edges);
+
+        tracing::debug!(
+            "group_nodes: selected={} internal={} outgoing={} (dropped={}) incoming={} (dropped={}) deduped_out={} deduped_in={}",
+            node_ids.len(),
+            internal_edges.len(),
+            outgoing_edges.len(),
+            dropped_outgoing.len(),
+            incoming_edges.len(),
+            dropped_incoming.len(),
+            deduped_outgoing.len(),
+            deduped_incoming.len(),
+        );
+
+        // 4. Create SubGraphNode
+        let subgraph_id = self.create_node::<SubGraphNode>()?;
+
+        // Get mutable access to the SubGraphNode
+        let subgraph_entity = self
+            .get_node_by_id(&subgraph_id)
+            .ok_or("SubGraphNode not found after creation")?;
+        let mut write_subgraph = subgraph_entity.write().map_err(|e| e.to_string())?;
+        let subgraph = write_subgraph
+            .as_any_mut()
+            .downcast_mut::<SubGraphNode>()
+            .ok_or("Failed to downcast to SubGraphNode")?;
+
+        subgraph.set_label(label);
+
+        // 5. Add input slots (one per unique source slot)
+        let mut input_slot_map: HashMap<EdgeId, usize> = HashMap::new();
+        for (idx, group) in deduped_incoming.iter().enumerate() {
+            let first = &group[0];
+            let data_type = self.get_edge_data_type(&first.edge)?;
+            // Use source node's output slot label (e.g. Vertex→"Position", Number→"Value")
+            let source_label = self
+                .get_node_by_id(&first.edge.from_node_id)
+                .and_then(|e| {
+                    e.read().ok().and_then(|g| {
+                        g.get_output_slot_by_index(first.edge.from_output_slot_index)
+                            .map(|s| s.label)
+                    })
+                })
+                .unwrap_or("");
+            let input_slot = InputSlot {
+                label: source_label,
+                data_type,
+                ..Default::default()
+            };
+            subgraph.add_input(input_slot)?;
+            for edge in group {
+                input_slot_map.insert(edge.edge_id, idx);
+            }
+        }
+
+        // 6. Add output slots (one per unique source slot from outgoing edges)
+        let mut output_slot_map: HashMap<EdgeId, usize> = HashMap::new();
+        for (idx, group) in deduped_outgoing.iter().enumerate() {
+            let first = &group[0];
+            let data_type = self.get_edge_data_type(&first.edge)?;
+            let source_label = self
+                .get_node_by_id(&first.edge.from_node_id)
+                .and_then(|e| {
+                    e.read().ok().and_then(|g| {
+                        g.get_output_slot_by_index(first.edge.from_output_slot_index)
+                            .map(|s| s.label)
+                    })
+                })
+                .unwrap_or("");
+            let output_slot = OutputSlot {
+                label: source_label,
+                data_type,
+                ..Default::default()
+            };
+            subgraph.add_output(output_slot)?;
+            for edge in group {
+                output_slot_map.insert(edge.edge_id, idx);
+            }
+        }
+
+        // 6b. Detect terminal outputs: output slots with no consumers at all.
+        //     These are slots that have neither internal consumers (no internal edges
+        //     from this slot) nor external consumers (no outgoing edges from this slot).
+        //     Example: Merge node at the end of a chain with no downstream node.
+        let consumed_slots: HashSet<(NodeId, usize)> = internal_edges
+            .iter()
+            .map(|e| (e.edge.from_node_id, e.edge.from_output_slot_index))
+            .chain(
+                outgoing_edges
+                    .iter()
+                    .map(|e| (e.edge.from_node_id, e.edge.from_output_slot_index)),
+            )
+            .chain(
+                dropped_outgoing
+                    .iter()
+                    .map(|e| (e.edge.from_node_id, e.edge.from_output_slot_index)),
+            )
+            .collect();
+
+        struct TerminalOutput {
+            node_id: NodeId,
+            slot_index: usize,
+            data_type: DataType,
+            label: &'static str,
+        }
+
+        let mut terminal_outputs: Vec<TerminalOutput> = Vec::new();
+        for &node_id in node_ids {
+            if let Some(node_entity) = self.get_node_by_id(&node_id) {
+                if let Ok(read_node) = node_entity.read() {
+                    for (slot_idx, slot) in read_node.outputs().iter().enumerate() {
+                        if !consumed_slots.contains(&(node_id, slot_idx))
+                            && !slot.label.starts_with('_')
+                        {
+                            terminal_outputs.push(TerminalOutput {
+                                node_id,
+                                slot_index: slot_idx,
+                                data_type: slot.data_type,
+                                label: slot.label,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add terminal outputs as additional SubGraphNode output slots
+        let terminal_start_idx = deduped_outgoing.len();
+        let mut terminal_slot_map: Vec<(NodeId, usize, usize)> = Vec::new();
+        for (i, terminal) in terminal_outputs.iter().enumerate() {
+            let output_slot = OutputSlot {
+                label: terminal.label,
+                data_type: terminal.data_type,
+                ..Default::default()
+            };
+            subgraph.add_output(output_slot)?;
+            terminal_slot_map.push((terminal.node_id, terminal.slot_index, terminal_start_idx + i));
+        }
+
+        tracing::debug!(
+            "group_nodes: terminal_outputs={}",
+            terminal_outputs.len(),
+        );
+
+        let input_proxy_id = subgraph.input_proxy_id();
+        let output_proxy_id = subgraph.output_proxy_id();
+        let internal_graph = subgraph.internal_graph_mut();
+
+        // 7. Create copies of selected nodes inside the internal graph
+        let mut node_id_remap: HashMap<NodeId, NodeId> = HashMap::new();
+        for &node_id in node_ids {
+            if let Some(node_entity) = self.get_node_by_id(&node_id) {
+                let read_node = node_entity.read().map_err(|e| e.to_string())?;
+                let type_name = read_node.node_name();
+                drop(read_node);
+
+                let internal_id = internal_graph.create_node_by_name(type_name)?;
+
+                // Copy node data
+                if let Some(original) = self.get_node_by_id(&node_id) {
+                    let read_original = original.read().map_err(|e| e.to_string())?;
+                    if let Some(data) = read_original.node_data() {
+                        drop(read_original);
+                        internal_graph.update_node_data(&internal_id, data)?;
+                    }
+                }
+
+                node_id_remap.insert(node_id, internal_id);
+            }
+        }
+
+        // 8. Recreate internal edges inside the subgraph
+        for boundary in &internal_edges {
+            let from_internal = node_id_remap
+                .get(&boundary.edge.from_node_id)
+                .ok_or("Internal edge source not in remap")?;
+            let to_internal = node_id_remap
+                .get(&boundary.edge.to_node_id)
+                .ok_or("Internal edge target not in remap")?;
+            internal_graph.connect_nodes(
+                from_internal,
+                boundary.edge.from_output_slot_index,
+                to_internal,
+                boundary.edge.to_input_slot_index,
+            )?;
+        }
+
+        // 9. Connect incoming edges: InputProxy → internal target
+        for boundary in &incoming_edges {
+            let proxy_output_idx = input_slot_map[&boundary.edge_id];
+            let internal_target = node_id_remap
+                .get(&boundary.edge.to_node_id)
+                .ok_or("Incoming edge target not in remap")?;
+            internal_graph.connect_nodes(
+                &input_proxy_id,
+                proxy_output_idx,
+                internal_target,
+                boundary.edge.to_input_slot_index,
+            )?;
+        }
+
+        // 10. Connect outgoing edges: internal source → OutputProxy
+        for boundary in &outgoing_edges {
+            let proxy_input_idx = output_slot_map[&boundary.edge_id];
+            let internal_source = node_id_remap
+                .get(&boundary.edge.from_node_id)
+                .ok_or("Outgoing edge source not in remap")?;
+            internal_graph.connect_nodes(
+                internal_source,
+                boundary.edge.from_output_slot_index,
+                &output_proxy_id,
+                proxy_input_idx,
+            )?;
+        }
+
+        // 10b. Connect terminal outputs: internal source → OutputProxy
+        for (node_id, slot_index, proxy_input_idx) in &terminal_slot_map {
+            let internal_source = node_id_remap
+                .get(node_id)
+                .ok_or("Terminal output node not in remap")?;
+            internal_graph.connect_nodes(
+                internal_source,
+                *slot_index,
+                &output_proxy_id,
+                *proxy_input_idx,
+            )?;
+        }
+
+        // Release the write lock before modifying the parent graph
+        drop(write_subgraph);
+
+        // 11. Rewire parent graph edges to go through SubGraphNode
+        // Incoming: external_source → SubGraphNode.input[idx]
+        // With source-based dedup, multiple edges from the same source map to the
+        // same input port. Deduplicate to avoid creating duplicate parent edges.
+        let mut created_parent_inputs: HashSet<(NodeId, usize, usize)> = HashSet::new();
+        for boundary in &incoming_edges {
+            let input_idx = input_slot_map[&boundary.edge_id];
+            self.remove_edge(boundary.edge_id)?;
+            let key = (
+                boundary.edge.from_node_id,
+                boundary.edge.from_output_slot_index,
+                input_idx,
+            );
+            if created_parent_inputs.insert(key) {
+                self.connect_nodes(
+                    &boundary.edge.from_node_id,
+                    boundary.edge.from_output_slot_index,
+                    &subgraph_id,
+                    input_idx,
+                )?;
+            }
+        }
+
+        // Outgoing: SubGraphNode.output[idx] → external_target
+        for boundary in &outgoing_edges {
+            let output_idx = output_slot_map[&boundary.edge_id];
+            self.remove_edge(boundary.edge_id)?;
+            self.connect_nodes(
+                &subgraph_id,
+                output_idx,
+                &boundary.edge.to_node_id,
+                boundary.edge.to_input_slot_index,
+            )?;
+        }
+
+        // 12. Remove internal edges from parent
+        for boundary in &internal_edges {
+            // These may already be removed if they shared nodes with incoming/outgoing
+            let _ = self.remove_edge(boundary.edge_id);
+        }
+
+        // 13. Remove dropped boundary edges from parent
+        //     These are intermediate edges that were filtered out in step 2.
+        for boundary in &dropped_outgoing {
+            let _ = self.remove_edge(boundary.edge_id);
+        }
+        for boundary in &dropped_incoming {
+            let _ = self.remove_edge(boundary.edge_id);
+        }
+
+        // 14. Remove original nodes from parent graph
+        for &node_id in node_ids {
+            let _ = self.remove_node(node_id);
+        }
+
+        Ok(GroupResult {
+            subgraph_node_id: subgraph_id,
+            node_id_remap,
+        })
+    }
+
+    /// Ungroup a SubGraphNode, extracting its internal nodes back into the parent.
+    ///
+    /// The SubGraphNode is removed and its internal nodes are placed directly
+    /// in the parent graph. Edges are rewired to bypass the SubGraphNode.
+    pub fn ungroup_node(&mut self, subgraph_node_id: NodeId) -> Result<UngroupResult, String> {
+        // 1. Read SubGraphNode's internal state
+        let subgraph_entity = self
+            .get_node_by_id(&subgraph_node_id)
+            .ok_or("SubGraphNode not found")?;
+        let read_subgraph = subgraph_entity.read().map_err(|e| e.to_string())?;
+        let subgraph = read_subgraph
+            .as_any()
+            .downcast_ref::<SubGraphNode>()
+            .ok_or("Node is not a SubGraphNode")?;
+
+        let input_proxy_id = subgraph.input_proxy_id();
+        let output_proxy_id = subgraph.output_proxy_id();
+        let internal_graph = subgraph.internal_graph();
+
+        // 2. Collect internal nodes (excluding proxies)
+        let internal_cache = internal_graph.shared_cache();
+        let internal_cache_read = internal_cache.read()?;
+
+        // Get all internal node IDs by examining edges
+        let mut internal_node_ids: HashSet<NodeId> = HashSet::new();
+        for edge in internal_cache_read.edges.values() {
+            if edge.from_node_id != input_proxy_id && edge.from_node_id != output_proxy_id {
+                internal_node_ids.insert(edge.from_node_id);
+            }
+            if edge.to_node_id != input_proxy_id && edge.to_node_id != output_proxy_id {
+                internal_node_ids.insert(edge.to_node_id);
+            }
+        }
+
+        // 3. Collect edge info we need before dropping locks
+        // Edges from InputProxy → internal (maps proxy output slot → internal node/slot)
+        let mut input_proxy_edges: Vec<(usize, NodeId, usize)> = Vec::new(); // (proxy_out_idx, to_node, to_slot)
+        for edge in internal_cache_read.edges.values() {
+            if edge.from_node_id == input_proxy_id {
+                input_proxy_edges.push((
+                    edge.from_output_slot_index,
+                    edge.to_node_id,
+                    edge.to_input_slot_index,
+                ));
+            }
+        }
+
+        // Edges from internal → OutputProxy (maps internal node/slot → proxy input slot)
+        let mut output_proxy_edges: Vec<(NodeId, usize, usize)> = Vec::new(); // (from_node, from_slot, proxy_in_idx)
+        for edge in internal_cache_read.edges.values() {
+            if edge.to_node_id == output_proxy_id {
+                output_proxy_edges.push((
+                    edge.from_node_id,
+                    edge.from_output_slot_index,
+                    edge.to_input_slot_index,
+                ));
+            }
+        }
+
+        // Internal edges (between non-proxy nodes)
+        let mut internal_edges: Vec<(NodeId, usize, NodeId, usize)> = Vec::new();
+        for edge in internal_cache_read.edges.values() {
+            if edge.from_node_id != input_proxy_id
+                && edge.to_node_id != output_proxy_id
+                && internal_node_ids.contains(&edge.from_node_id)
+                && internal_node_ids.contains(&edge.to_node_id)
+            {
+                internal_edges.push((
+                    edge.from_node_id,
+                    edge.from_output_slot_index,
+                    edge.to_node_id,
+                    edge.to_input_slot_index,
+                ));
+            }
+        }
+
+        // Get internal node type names
+        let mut node_type_names: HashMap<NodeId, &'static str> = HashMap::new();
+        for &node_id in &internal_node_ids {
+            if let Some(node) = internal_graph.get_node_by_id(&node_id) {
+                if let Ok(read) = node.read() {
+                    node_type_names.insert(node_id, read.node_name());
+                }
+            }
+        }
+
+        drop(internal_cache_read);
+
+        // 4. Collect parent graph edges to/from SubGraphNode
+        let parent_cache = self.shared_cache();
+        let parent_cache_read = parent_cache.read()?;
+
+        // Edges entering SubGraphNode (external → subgraph.input[idx])
+        let mut parent_incoming: Vec<(NodeId, usize, usize, EdgeId)> = Vec::new(); // (from_node, from_slot, to_slot_idx, edge_id)
+        for (&edge_id, edge) in &parent_cache_read.edges {
+            if edge.to_node_id == subgraph_node_id {
+                parent_incoming.push((
+                    edge.from_node_id,
+                    edge.from_output_slot_index,
+                    edge.to_input_slot_index,
+                    edge_id,
+                ));
+            }
+        }
+
+        // Edges leaving SubGraphNode (subgraph.output[idx] → external)
+        let mut parent_outgoing: Vec<(usize, NodeId, usize, EdgeId)> = Vec::new(); // (from_slot_idx, to_node, to_slot, edge_id)
+        for (&edge_id, edge) in &parent_cache_read.edges {
+            if edge.from_node_id == subgraph_node_id {
+                parent_outgoing.push((
+                    edge.from_output_slot_index,
+                    edge.to_node_id,
+                    edge.to_input_slot_index,
+                    edge_id,
+                ));
+            }
+        }
+
+        drop(parent_cache_read);
+        drop(read_subgraph);
+
+        // 5. Create copies of internal nodes in parent graph
+        let mut node_id_remap: HashMap<NodeId, NodeId> = HashMap::new();
+        for &internal_id in &internal_node_ids {
+            if let Some(&type_name) = node_type_names.get(&internal_id) {
+                let parent_id = self.create_node_by_name(type_name)?;
+                node_id_remap.insert(internal_id, parent_id);
+            }
+        }
+
+        // 6. Recreate internal edges in parent
+        for (from_id, from_slot, to_id, to_slot) in &internal_edges {
+            if let (Some(new_from), Some(new_to)) =
+                (node_id_remap.get(from_id), node_id_remap.get(to_id))
+            {
+                self.connect_nodes(new_from, *from_slot, new_to, *to_slot)?;
+            }
+        }
+
+        // 7. Rewire incoming edges: external → internal node that was connected to InputProxy
+        for (ext_from, ext_from_slot, subgraph_input_idx, edge_id) in &parent_incoming {
+            self.remove_edge(*edge_id)?;
+            // Find which internal node the InputProxy output[subgraph_input_idx] was connected to
+            for (proxy_out_idx, internal_to, internal_to_slot) in &input_proxy_edges {
+                if *proxy_out_idx == *subgraph_input_idx {
+                    if let Some(new_to) = node_id_remap.get(internal_to) {
+                        self.connect_nodes(ext_from, *ext_from_slot, new_to, *internal_to_slot)?;
+                    }
+                }
+            }
+        }
+
+        // 8. Rewire outgoing edges: internal node → external
+        for (subgraph_output_idx, ext_to, ext_to_slot, edge_id) in &parent_outgoing {
+            self.remove_edge(*edge_id)?;
+            // Find which internal node was connected to OutputProxy input[subgraph_output_idx]
+            for (internal_from, internal_from_slot, proxy_in_idx) in &output_proxy_edges {
+                if *proxy_in_idx == *subgraph_output_idx {
+                    if let Some(new_from) = node_id_remap.get(internal_from) {
+                        self.connect_nodes(new_from, *internal_from_slot, ext_to, *ext_to_slot)?;
+                    }
+                }
+            }
+        }
+
+        // 9. Remove the SubGraphNode from parent
+        self.remove_node(subgraph_node_id)?;
+
+        let extracted_node_ids: Vec<NodeId> = node_id_remap.values().copied().collect();
+        Ok(UngroupResult {
+            extracted_node_ids,
+        })
+    }
+
+    /// Classify edges relative to a set of selected node IDs.
+    fn classify_boundary_edges(
+        &self,
+        selected: &HashSet<NodeId>,
+    ) -> Result<(Vec<BoundaryEdge>, Vec<BoundaryEdge>, Vec<BoundaryEdge>), String> {
+        let cache = self.shared_cache();
+        let cache_read = cache.read()?;
+
+        let mut incoming = Vec::new(); // external → selected
+        let mut outgoing = Vec::new(); // selected → external
+        let mut internal = Vec::new(); // selected → selected
+
+        for (&edge_id, edge) in &cache_read.edges {
+            let from_selected = selected.contains(&edge.from_node_id);
+            let to_selected = selected.contains(&edge.to_node_id);
+
+            match (from_selected, to_selected) {
+                (false, true) => incoming.push(BoundaryEdge {
+                    edge_id,
+                    edge: edge.clone(),
+                }),
+                (true, false) => outgoing.push(BoundaryEdge {
+                    edge_id,
+                    edge: edge.clone(),
+                }),
+                (true, true) => internal.push(BoundaryEdge {
+                    edge_id,
+                    edge: edge.clone(),
+                }),
+                (false, false) => {} // Not relevant
+            }
+        }
+
+        Ok((incoming, outgoing, internal))
+    }
+
+    /// Get the DataType for an edge by examining its source output slot.
+    fn get_edge_data_type(&self, edge: &Edge) -> Result<DataType, String> {
+        let node = self
+            .get_node_by_id(&edge.from_node_id)
+            .ok_or("Edge source node not found")?;
+        let read_node = node.read().map_err(|e| e.to_string())?;
+        let slot = read_node
+            .get_output_slot_by_index(edge.from_output_slot_index)
+            .ok_or("Edge source output slot not found")?;
+        Ok(slot.data_type)
+    }
+
+    /// Group outgoing edges by source slot (from_node_id, from_output_slot_index).
+    /// Returns groups of edges that share the same source; one SubGraphNode output
+    /// port is created per group.
+    fn dedup_outgoing(edges: &[BoundaryEdge]) -> Vec<Vec<&BoundaryEdge>> {
+        let mut groups: HashMap<(NodeId, usize), Vec<&BoundaryEdge>> = HashMap::new();
+        for edge in edges {
+            groups
+                .entry((edge.edge.from_node_id, edge.edge.from_output_slot_index))
+                .or_default()
+                .push(edge);
+        }
+        groups.into_values().collect()
+    }
+
+    /// Group incoming edges by source slot (from_node_id, from_output_slot_index).
+    /// Returns groups of edges that share the same source; one SubGraphNode input
+    /// port is created per group. The InputProxy fans out to multiple internal targets.
+    fn dedup_incoming(edges: &[BoundaryEdge]) -> Vec<Vec<&BoundaryEdge>> {
+        let mut groups: HashMap<(NodeId, usize), Vec<&BoundaryEdge>> = HashMap::new();
+        for edge in edges {
+            groups
+                .entry((edge.edge.from_node_id, edge.edge.from_output_slot_index))
+                .or_default()
+                .push(edge);
+        }
+        groups.into_values().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NodeGraphAPI;
+
+    #[tokio::test]
+    async fn test_group_and_ungroup() {
+        let mut graph = NodeGraph::new().expect("Failed to create graph");
+
+        // Create a simple chain: Number → Add → NumberOutput
+        let num1 = graph
+            .create_node::<crate::NumberNode>()
+            .expect("create num1");
+        let num2 = graph
+            .create_node::<crate::NumberNode>()
+            .expect("create num2");
+        let add = graph.create_node::<crate::AddNode>().expect("create add");
+        let output = graph
+            .create_node::<crate::NumberOutput>()
+            .expect("create output");
+
+        // Connect: num1 → add.input0, num2 → add.input1, add → output
+        graph
+            .connect_nodes(&num1, 0, &add, 0)
+            .expect("connect num1→add");
+        graph
+            .connect_nodes(&num2, 0, &add, 1)
+            .expect("connect num2→add");
+        graph
+            .connect_nodes(&add, 0, &output, 0)
+            .expect("connect add→output");
+
+        // Group the Add node
+        let selected: HashSet<NodeId> = [add].into_iter().collect();
+        let result = graph
+            .group_nodes(&selected, "TestGroup")
+            .expect("group_nodes");
+
+        // Verify SubGraphNode was created
+        let sg_entity = graph
+            .get_node_by_id(&result.subgraph_node_id)
+            .expect("subgraph exists");
+        let read_sg = sg_entity.read().expect("read");
+        assert_eq!(read_sg.node_name(), "SubGraph");
+        // Should have 2 inputs (from num1 and num2) and 1 output (to output)
+        assert_eq!(read_sg.inputs().len(), 2);
+        assert_eq!(read_sg.outputs().len(), 1);
+        drop(read_sg);
+
+        // Verify original add node was removed
+        assert!(graph.get_node_by_id(&add).is_none());
+
+        // Ungroup
+        let ungroup_result = graph
+            .ungroup_node(result.subgraph_node_id)
+            .expect("ungroup_node");
+        assert_eq!(ungroup_result.extracted_node_ids.len(), 1);
+
+        // Verify SubGraphNode was removed
+        assert!(graph.get_node_by_id(&result.subgraph_node_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_group_empty_fails() {
+        let mut graph = NodeGraph::new().expect("Failed to create graph");
+        let selected: HashSet<NodeId> = HashSet::new();
+        assert!(graph.group_nodes(&selected, "Empty").is_err());
+    }
+
+    /// Test that intermediate outputs (source slot also feeds internal nodes)
+    /// are filtered out and not exposed as SubGraphNode ports.
+    #[tokio::test]
+    async fn test_group_filters_intermediate_outputs() {
+        let mut graph = NodeGraph::new().expect("Failed to create graph");
+
+        // Graph: num1 → add → multiply → output
+        //                add → external_consumer (intermediate tap)
+        let num1 = graph.create_node::<crate::NumberNode>().unwrap();
+        let add = graph.create_node::<crate::AddNode>().unwrap();
+        let mul = graph.create_node::<crate::MultiplyNode>().unwrap();
+        let output = graph.create_node::<crate::NumberOutput>().unwrap();
+        let external = graph.create_node::<crate::NumberOutput>().unwrap();
+
+        graph.connect_nodes(&num1, 0, &add, 0).unwrap();
+        graph.connect_nodes(&add, 0, &mul, 0).unwrap();  // internal
+        graph.connect_nodes(&add, 0, &external, 0).unwrap(); // intermediate tap
+        graph.connect_nodes(&mul, 0, &output, 0).unwrap();
+
+        // Select add + multiply (not num1, output, external)
+        let selected: HashSet<NodeId> = [add, mul].into_iter().collect();
+        let result = graph.group_nodes(&selected, "FilterTest").unwrap();
+
+        let sg_entity = graph.get_node_by_id(&result.subgraph_node_id).unwrap();
+        let read_sg = sg_entity.read().unwrap();
+
+        // 1 input (from num1). Add's second input (slot 1) has no edge → no port.
+        assert_eq!(read_sg.inputs().len(), 1, "should have 1 input port");
+        // 1 output (mul→output). The add→external edge is intermediate
+        // (add's output also feeds mul internally) and should be filtered out.
+        assert_eq!(read_sg.outputs().len(), 1, "should have 1 output port (intermediate filtered)");
+    }
+
+    /// Test terminal output detection: a node with no downstream consumers
+    /// should automatically get an output port on the SubGraphNode.
+    #[tokio::test]
+    async fn test_group_terminal_output() {
+        let mut graph = NodeGraph::new().expect("Failed to create graph");
+
+        // Graph: num1 → add (no downstream from add)
+        let num1 = graph.create_node::<crate::NumberNode>().unwrap();
+        let add = graph.create_node::<crate::AddNode>().unwrap();
+
+        graph.connect_nodes(&num1, 0, &add, 0).unwrap();
+
+        // Select only the add node
+        let selected: HashSet<NodeId> = [add].into_iter().collect();
+        let result = graph.group_nodes(&selected, "TerminalTest").unwrap();
+
+        let sg_entity = graph.get_node_by_id(&result.subgraph_node_id).unwrap();
+        let read_sg = sg_entity.read().unwrap();
+
+        // 1 input (from num1)
+        assert_eq!(read_sg.inputs().len(), 1, "should have 1 input port");
+        // 1 output (add.output0 is terminal — no consumers)
+        assert_eq!(read_sg.outputs().len(), 1, "should have 1 terminal output port");
+    }
+
+    /// Test source-based dedup: same source feeding multiple internal targets
+    /// should produce only one input port with fan-out inside the subgraph.
+    #[tokio::test]
+    async fn test_group_source_dedup() {
+        let mut graph = NodeGraph::new().expect("Failed to create graph");
+
+        // Graph: source → A.input0, source → B.input0
+        //        (same source output feeds two different internal nodes)
+        let source = graph.create_node::<crate::NumberNode>().unwrap();
+        let a = graph.create_node::<crate::AddNode>().unwrap();
+        let b = graph.create_node::<crate::AddNode>().unwrap();
+        let out_a = graph.create_node::<crate::NumberOutput>().unwrap();
+        let out_b = graph.create_node::<crate::NumberOutput>().unwrap();
+
+        graph.connect_nodes(&source, 0, &a, 0).unwrap();
+        graph.connect_nodes(&source, 0, &b, 0).unwrap();
+        graph.connect_nodes(&a, 0, &out_a, 0).unwrap();
+        graph.connect_nodes(&b, 0, &out_b, 0).unwrap();
+
+        // Select A and B (not source, not outputs)
+        let selected: HashSet<NodeId> = [a, b].into_iter().collect();
+        let result = graph.group_nodes(&selected, "DedupTest").unwrap();
+
+        let sg_entity = graph.get_node_by_id(&result.subgraph_node_id).unwrap();
+        let read_sg = sg_entity.read().unwrap();
+
+        // With source-based dedup: source.output0 → 1 input port (fans out to A and B)
+        assert_eq!(read_sg.inputs().len(), 1, "should have 1 input port (source deduped)");
+        // 2 outputs (A→out_a, B→out_b)
+        assert_eq!(read_sg.outputs().len(), 2, "should have 2 output ports");
+    }
+}

--- a/src/state_access.rs
+++ b/src/state_access.rs
@@ -1,0 +1,178 @@
+//! External state access trait for decoupled state management.
+//!
+//! This module provides the `NodeStatesAccess` trait which allows cognet
+//! to delegate state management to external consumers (like revion).
+//!
+//! # Design Philosophy
+//!
+//! cognet is a graph computation engine that should remain independent of
+//! UI frameworks. However, UI systems need to observe graph state changes
+//! for rendering. This trait provides a clean abstraction:
+//!
+//! - cognet defines what state operations are needed
+//! - UI frameworks implement how to store and notify about changes
+//!
+//! # Fine-grained API
+//!
+//! The trait provides individual methods for each type of mutation,
+//! allowing implementations to:
+//! - Track exactly what changed (for incremental rendering)
+//! - Trigger notifications only when needed
+//! - Optimize for their specific use case
+
+use crate::{Data, Edge, EdgeId, NodeId, NodeStates};
+use std::sync::{Arc, RwLock};
+
+/// Trait for external state access with fine-grained updates.
+///
+/// cognet is independent - consumers provide their own implementation.
+///
+/// # Example Implementation
+///
+/// ```ignore
+/// struct MyStateAdapter {
+///     storage: Arc<RwLock<NodeStates>>,
+///     on_change: Box<dyn Fn() + Send + Sync>,
+/// }
+///
+/// impl NodeStatesAccess for MyStateAdapter {
+///     fn storage(&self) -> &Arc<RwLock<NodeStates>> {
+///         &self.storage
+///     }
+///
+///     fn add_node(&self, node_id: NodeId, ...) {
+///         self.storage.write().unwrap().add_node(...);
+///         (self.on_change)();
+///     }
+///     // ... implement other methods
+/// }
+/// ```
+pub trait NodeStatesAccess: Send + Sync {
+    // ========================================================================
+    // Read Operations
+    // ========================================================================
+
+    /// Get the underlying storage for direct read access.
+    ///
+    /// This provides access to the Arc<RwLock<NodeStates>> for reading.
+    /// Use `storage().read()` to get a read guard.
+    fn storage(&self) -> &Arc<RwLock<NodeStates>>;
+
+    // ========================================================================
+    // Node Operations
+    // ========================================================================
+
+    /// Add a node with its initial state.
+    ///
+    /// This should be called after the node is created in NodeManager.
+    fn add_node(
+        &self,
+        node_id: NodeId,
+        type_name: &'static str,
+        data: Option<Data>,
+        input_count: usize,
+        output_count: usize,
+    );
+
+    /// Remove a node and its slot states.
+    fn remove_node(&self, node_id: NodeId);
+
+    /// Update a node's data value.
+    fn update_node_data(&self, node_id: NodeId, data: Option<Data>);
+
+    // ========================================================================
+    // Edge Operations
+    // ========================================================================
+
+    /// Add an edge.
+    fn add_edge(&self, edge_id: EdgeId, edge: Edge);
+
+    /// Remove an edge.
+    fn remove_edge(&self, edge_id: EdgeId);
+
+    // ========================================================================
+    // Slot Operations
+    // ========================================================================
+
+    /// Update input slot's connected edges.
+    fn update_input_slot_edges(&self, node_id: NodeId, slot_index: usize, edges: Vec<EdgeId>);
+
+    /// Update output slot's connected edges.
+    fn update_output_slot_edges(&self, node_id: NodeId, slot_index: usize, edges: Vec<EdgeId>);
+}
+
+/// A simple implementation that operates directly on NodeStates.
+///
+/// This is used when no external state access is provided (standalone mode).
+pub struct InternalStateAccess {
+    states: Arc<RwLock<NodeStates>>,
+}
+
+impl InternalStateAccess {
+    /// Create a new internal state access.
+    pub fn new() -> Self {
+        Self {
+            states: Arc::new(RwLock::new(NodeStates::new())),
+        }
+    }
+}
+
+impl Default for InternalStateAccess {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NodeStatesAccess for InternalStateAccess {
+    fn storage(&self) -> &Arc<RwLock<NodeStates>> {
+        &self.states
+    }
+
+    fn add_node(
+        &self,
+        node_id: NodeId,
+        type_name: &'static str,
+        data: Option<Data>,
+        input_count: usize,
+        output_count: usize,
+    ) {
+        let mut guard = self.states.write().expect("lock poisoned");
+        guard.add_node(node_id, type_name, data, input_count, output_count);
+    }
+
+    fn remove_node(&self, node_id: NodeId) {
+        let mut guard = self.states.write().expect("lock poisoned");
+        guard.remove_node(&node_id);
+    }
+
+    fn update_node_data(&self, node_id: NodeId, data: Option<Data>) {
+        let mut guard = self.states.write().expect("lock poisoned");
+        if let Some(node) = guard.get_mut(&node_id) {
+            node.data = data;
+        }
+    }
+
+    fn add_edge(&self, edge_id: EdgeId, edge: Edge) {
+        let mut guard = self.states.write().expect("lock poisoned");
+        guard.add_edge(edge_id, edge);
+    }
+
+    fn remove_edge(&self, edge_id: EdgeId) {
+        let mut guard = self.states.write().expect("lock poisoned");
+        guard.remove_edge(&edge_id);
+    }
+
+    fn update_input_slot_edges(&self, node_id: NodeId, slot_index: usize, edges: Vec<EdgeId>) {
+        let mut guard = self.states.write().expect("lock poisoned");
+        if let Some(slot) = guard.input_slot_mut(&node_id, slot_index) {
+            slot.connected_edges = edges;
+        }
+    }
+
+    fn update_output_slot_edges(&self, node_id: NodeId, slot_index: usize, edges: Vec<EdgeId>) {
+        let mut guard = self.states.write().expect("lock poisoned");
+        if let Some(slot) = guard.output_slot_mut(&node_id, slot_index) {
+            slot.connected_edges = edges;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Closes #N/A

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Tests
- [ ] Other

## What's new?

- Add hierarchical subgraph composition via `SubGraphNode`, `SubGraphInputNode`,
  and `SubGraphOutputNode`, enabling modular graph design and reuse
- Add `group_nodes` / `ungroup_node` operations to create and dissolve subgraphs
  from selected nodes, with automatic proxy port generation
- Introduce new data types: `Mesh`, `Vertices`, `Bool`, `Vector3`, `Color`,
  `BRep`, and `Domain` -- expanding the range of values the graph can carry
- Add primitive nodes for the new types (`Vector3Node`, `ColorNode`,
  `VertexNode`) and math operators (Subtract, Multiply, division, List variants)
- Refactor execution layer: replace async/tokio with standard threads,
  switch cache lock from `Mutex` to `RwLock`, add outgoing-edge index, and
  report progress via callback -- improving throughput and responsiveness
- Decouple state management with `NodeStatesAccess` trait and declarative
  `NodeMeta`/`NodeInit` traits for node definitions

## Implementation Details

- `SubGraphNode` executes its internal `NodeGraph` during the parent graph's
  execution pass; panic recovery is added for individual node execution and
  poisoned mutexes
- Cache eviction now supports targeted removal of `Mesh` outputs to free
  memory when geometry is no longer needed
- Change tracking on graph execution records updated outputs and removed
  nodes, enabling efficient UI updates downstream
- Claude Code tooling (`.claude/` agents, commands, rules) added to
  standardize development workflow -- not part of the runtime

## Screenshots

N/A

## Testing

- [x] Build passes
- [x] Manual testing performed on node graph execution
