### PR TITLE
fix: Remove invalid `.await` calls on sync methods and unused import

### DIFF
--- a/examples/add.rs
+++ b/examples/add.rs
@@ -4,18 +4,18 @@ use cognet::{AddNode, Data, NodeGraph, NodeGraphAPI, NumberNode};
 async fn main() -> Result<(), String> {
     let mut graph = NodeGraph::new()?;
 
-    let node1_id = graph.create_node::<NumberNode>().await?;
-    graph.update_node_data(&node1_id, Data::new(10.)?).await?;
-    let node2_id = graph.create_node::<NumberNode>().await?;
-    graph.update_node_data(&node2_id, Data::new(20.)?).await?;
-    let node3_id = graph.create_node::<AddNode>().await?;
+    let node1_id = graph.create_node::<NumberNode>()?;
+    graph.update_node_data(&node1_id, Data::new(10.)?)?;
+    let node2_id = graph.create_node::<NumberNode>()?;
+    graph.update_node_data(&node2_id, Data::new(20.)?)?;
+    let node3_id = graph.create_node::<AddNode>()?;
 
-    graph.connect_nodes(&node1_id, 0, &node3_id, 0).await?;
-    graph.connect_nodes(&node2_id, 0, &node3_id, 0).await?;
+    graph.connect_nodes(&node1_id, 0, &node3_id, 0)?;
+    graph.connect_nodes(&node2_id, 0, &node3_id, 0)?;
 
     graph.execute().await?;
 
-    let data = graph.get_output_value(&node3_id, 0).await.unwrap();
+    let data = graph.get_output_value(&node3_id, 0).unwrap();
     let output = data.value::<f64>()?;
     assert_eq!(*output, 30.);
 

--- a/src/node_graph/mod.rs
+++ b/src/node_graph/mod.rs
@@ -104,8 +104,6 @@ impl NodeGraph {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     fn test_execute() {}
 }


### PR DESCRIPTION
## Description

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## What's new?

- Remove invalid `.await` calls on `NodeGraphAPI` methods in `examples/add.rs`
  -- these methods are now synchronous after the async/tokio removal, so
  awaiting them caused compile errors
- Remove unused `use super::*` import from the empty test module in
  `src/node_graph/mod.rs` to silence the unused-import warning

## Implementation Details

- Affected files: `examples/add.rs`, `src/node_graph/mod.rs`
- The `.await` removals are a follow-up to the earlier refactor that replaced
  async `NodeGraphAPI` methods with synchronous equivalents

## Screenshots

N/A

## Testing

- [x] Build passes