### PR TITLE
plan-14c: hybrid sync/async executor with typed errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,64 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,12 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "bytes"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,30 +30,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "cognet"
 version = "0.1.0"
 dependencies = [
- "async-lock",
- "async-trait",
- "futures",
  "getrandom",
  "inventory",
  "rayon",
  "serde",
  "strum",
  "thiserror",
- "tokio",
  "tracing",
  "ulid",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "wasm-bindgen-rayon",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -161,116 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "event-listener"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,16 +91,10 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
+ "wasi",
  "wasm-bindgen",
  "windows-targets",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "inventory"
@@ -316,55 +122,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
-
-[[package]]
-name = "memchr"
-version = "2.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
-dependencies = [
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "once_cell"
@@ -373,45 +134,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -494,31 +220,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -538,40 +243,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "socket2"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
-dependencies = [
- "libc",
- "windows-sys",
 ]
 
 [[package]]
@@ -605,35 +276,6 @@ name = "thiserror-impl"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio"
-version = "1.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
-dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -689,12 +331,6 @@ checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasi"
 version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
@@ -726,19 +362,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -814,15 +437,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,12 +30,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "cognet"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "getrandom",
  "inventory",
  "rayon",
  "serde",
  "strum",
  "thiserror",
+ "tokio",
  "tracing",
  "ulid",
  "wasm-bindgen",
@@ -83,6 +85,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +216,12 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "once_cell"
@@ -246,6 +342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "strum"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +378,27 @@ name = "thiserror-impl"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.1.0"
 crate-type = ["rlib"]
 
 [dependencies]
+futures = "0.3.31"
 inventory = "0.3.19"
 rayon = "1.10"
 serde = {version = "1.0", features = ["derive"]}
@@ -26,3 +27,6 @@ wasm-bindgen-rayon = "1.3.0"
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = {version = "0.3.1", features = ["wasm_js"]}
+
+[dev-dependencies]
+tokio = {version = "1.43.0", features = ["macros", "rt-multi-thread"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ version = "0.1.0"
 crate-type = ["rlib"]
 
 [dependencies]
-async-lock = "3.4.0"
-async-trait = "0.1.86"
-futures = "0.3.31"
 inventory = "0.3.19"
 rayon = "1.10"
 serde = {version = "1.0", features = ["derive"]}
@@ -25,11 +22,7 @@ thiserror = "2.0.11"
 tracing = "0.1.41"
 ulid = "1.2.0"
 wasm-bindgen = "0.2.100"
-wasm-bindgen-futures = "0.4.50"
 wasm-bindgen-rayon = "1.3.0"
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = {version = "0.3.1", features = ["wasm_js"]}
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = {version = "1.43.0", features = ["full"]}

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -1,7 +1,6 @@
 use cognet::{AddNode, Data, NodeGraph, NodeGraphRead, NodeGraphWrite, NumberNode};
 
-#[tokio::main]
-async fn main() -> Result<(), String> {
+fn main() -> Result<(), String> {
     let mut graph = NodeGraph::new()?;
 
     let node1_id = graph.create_node::<NumberNode>()?;
@@ -13,7 +12,7 @@ async fn main() -> Result<(), String> {
     graph.connect_nodes(&node1_id, 0, &node3_id, 0)?;
     graph.connect_nodes(&node2_id, 0, &node3_id, 0)?;
 
-    graph.execute().await?;
+    graph.execute_sync()?;
 
     let data = graph.get_output_value(&node3_id, 0).unwrap();
     let output = data.value::<f64>()?;

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), String> {
     graph.connect_nodes(&node1_id, 0, &node3_id, 0)?;
     graph.connect_nodes(&node2_id, 0, &node3_id, 0)?;
 
-    graph.execute_sync()?;
+    graph.execute_sync().map_err(|e| e.to_string())?;
 
     let data = graph.get_output_value(&node3_id, 0).unwrap();
     let output = data.value::<f64>()?;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -13,7 +13,7 @@ pub use subgraph::*;
 pub use type_info::*;
 
 use crate::{impl_entity_id, AsAny, NodeManager};
-use std::{any::Any, fmt::Debug};
+use std::{any::Any, fmt::Debug, future::Future, pin::Pin};
 
 impl_entity_id!(NodeId);
 
@@ -28,11 +28,85 @@ pub trait NodeInit: NodeMeta + Sized {
     fn initialize() -> Result<Self, String>;
 }
 
+/// Capability metadata describing how a node should be executed.
+///
+/// The graph executor inspects this to dispatch CPU-bound work synchronously
+/// (potentially in parallel via rayon) and I/O-bound work asynchronously.
+/// `SyncCpu` nodes implement [`NodeImpl::execute_sync`]; `AsyncIo` nodes
+/// implement [`NodeImpl::prepare_async`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NodeExecutionKind {
+    /// CPU-bound, deterministic, runs to completion without yielding to an
+    /// async runtime. Default for all primitive and operator nodes.
+    #[default]
+    SyncCpu,
+    /// I/O-bound. Must yield to an async runtime via the future returned
+    /// from `prepare_async`.
+    AsyncIo,
+}
+
+/// `'static` boxed future returned by [`NodeImpl::prepare_async`].
+///
+/// The future must own (or `Arc`-clone) every input it needs — the graph
+/// executor drops all node and graph locks before awaiting it. This is the
+/// invariant that prevents nested `block_on` and lock-across-`await`
+/// deadlocks.
+pub type BoxNodeFuture = Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'static>>;
+
 /// The core node implementation trait.
-/// Only requires `execute()` - initialization is handled by `NodeInit`.
-#[async_trait::async_trait]
+///
+/// Nodes split into two camps via [`NodeExecutionKind`]:
+///
+/// - **`SyncCpu`** (default) — implement [`NodeImpl::execute_sync`]. The
+///   executor runs them on the current thread (or a rayon worker) inside
+///   `NodeGraph::execute_sync`. They never enter an async runtime.
+/// - **`AsyncIo`** — implement [`NodeImpl::prepare_async`]. The executor
+///   calls `prepare_async` under a short read lock to obtain a `'static`
+///   future, drops the lock, then awaits the future. Use for remote API
+///   calls, asset loading, database access — anything that yields.
+///
+/// `NodeGraph::execute_sync` returns
+/// [`crate::GraphExecutionError::RequiresAsyncExecution`] if the dirty
+/// plan reaches an `AsyncIo` node. Use `NodeGraph::execute_async` for
+/// mixed graphs.
 pub trait NodeImpl: Debug + Send + Sync + AsAny {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String>;
+    /// How the executor should dispatch this node.
+    ///
+    /// Default is [`NodeExecutionKind::SyncCpu`]. Override and implement
+    /// [`NodeImpl::prepare_async`] for I/O-bound nodes.
+    fn execution_kind(&self) -> NodeExecutionKind {
+        NodeExecutionKind::SyncCpu
+    }
+
+    /// Synchronous execution entry point for `SyncCpu` nodes.
+    ///
+    /// Default implementation returns an error so a forgotten override
+    /// surfaces as a runtime failure rather than silently doing nothing.
+    fn execute_sync(&self, _ctx: ExecutionContext) -> Result<(), String> {
+        Err(format!(
+            "node `{}` does not implement synchronous execution; \
+             override `NodeImpl::execute_sync` or set \
+             `execution_kind() == NodeExecutionKind::AsyncIo` and implement `prepare_async`",
+            std::any::type_name::<Self>()
+        ))
+    }
+
+    /// Async preparation entry point for `AsyncIo` nodes.
+    ///
+    /// The implementation is called by the executor under a short read
+    /// lock on the node entity. It must extract every input it needs from
+    /// `ctx`, then return a `'static` future that owns its captured data.
+    /// The executor drops all locks before awaiting that future, which is
+    /// the invariant that keeps the executor free of nested `block_on`
+    /// and `RwLock` guards across `.await`.
+    fn prepare_async(&self, _ctx: ExecutionContext) -> Result<BoxNodeFuture, String> {
+        Err(format!(
+            "node `{}` does not implement asynchronous execution; \
+             override `NodeImpl::prepare_async` or set \
+             `execution_kind() == NodeExecutionKind::SyncCpu` and implement `execute_sync`",
+            std::any::type_name::<Self>()
+        ))
+    }
 }
 
 impl dyn NodeImpl {

--- a/src/node/operators/add.rs
+++ b/src/node/operators/add.rs
@@ -28,9 +28,8 @@ impl NodeMeta for AddNode {
     }];
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for AddNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let a: f64 = ctx
             .input_values
             .first()

--- a/src/node/operators/add_list.rs
+++ b/src/node/operators/add_list.rs
@@ -21,9 +21,8 @@ impl NodeMeta for AddListNode {
     }];
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for AddListNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let data_list = ctx.input_values.first().cloned().unwrap_or_default();
         let mut result = 0.0_f64;
         for data in &data_list {

--- a/src/node/operators/divide.rs
+++ b/src/node/operators/divide.rs
@@ -32,9 +32,8 @@ impl NodeMeta for DivideNode {
     }];
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for DivideNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let a: f64 = ctx
             .input_values
             .first()

--- a/src/node/operators/divide_list.rs
+++ b/src/node/operators/divide_list.rs
@@ -26,9 +26,8 @@ impl NodeMeta for DivideListNode {
     }];
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for DivideListNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let data_list = ctx.input_values.first().cloned().unwrap_or_default();
         let mut result: Option<f64> = None;
         for data in &data_list {

--- a/src/node/operators/multiply.rs
+++ b/src/node/operators/multiply.rs
@@ -27,9 +27,8 @@ impl NodeMeta for MultiplyNode {
     }];
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for MultiplyNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let a: f64 = ctx
             .input_values
             .first()

--- a/src/node/operators/multiply_list.rs
+++ b/src/node/operators/multiply_list.rs
@@ -21,9 +21,8 @@ impl NodeMeta for MultiplyListNode {
     }];
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for MultiplyListNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let data_list = ctx.input_values.first().cloned().unwrap_or_default();
         let mut result = 1.0_f64;
         for data in &data_list {

--- a/src/node/operators/subtract.rs
+++ b/src/node/operators/subtract.rs
@@ -27,9 +27,8 @@ impl NodeMeta for SubtractNode {
     }];
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for SubtractNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let a: f64 = ctx
             .input_values
             .first()

--- a/src/node/operators/subtract_list.rs
+++ b/src/node/operators/subtract_list.rs
@@ -21,9 +21,8 @@ impl NodeMeta for SubtractListNode {
     }];
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for SubtractListNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let data_list = ctx.input_values.first().cloned().unwrap_or_default();
         let mut result: Option<f64> = None;
         for data in &data_list {

--- a/src/node/outputs/number_output.rs
+++ b/src/node/outputs/number_output.rs
@@ -16,9 +16,8 @@ impl NodeMeta for NumberOutput {
     const OUTPUTS: &'static [SlotDef] = &[];
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for NumberOutput {
-    async fn execute(&self, _ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, _ctx: ExecutionContext) -> Result<(), String> {
         // Output node just reads its input - the value is read from cache for UI display
         Ok(())
     }

--- a/src/node/outputs/string_output.rs
+++ b/src/node/outputs/string_output.rs
@@ -16,9 +16,8 @@ impl NodeMeta for StringOutput {
     const OUTPUTS: &'static [SlotDef] = &[];
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for StringOutput {
-    async fn execute(&self, _ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, _ctx: ExecutionContext) -> Result<(), String> {
         // Output node just reads its input - the value is read from cache for UI display
         Ok(())
     }

--- a/src/node/primitives/color.rs
+++ b/src/node/primitives/color.rs
@@ -29,9 +29,8 @@ impl NodeMeta for ColorNode {
     };
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for ColorNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let node_data = ctx.node_data.ok_or("Failed to get node data")?;
         ctx.output_writer.set(0, node_data)?;
         Ok(())

--- a/src/node/primitives/number.rs
+++ b/src/node/primitives/number.rs
@@ -18,9 +18,8 @@ impl NodeMeta for NumberNode {
     const DEFAULT_VALUE: DefaultValue = DefaultValue::Number(10.0);
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for NumberNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let node_data = ctx.node_data.ok_or("Failed to get node data")?;
         ctx.output_writer.set(0, node_data)?;
         Ok(())

--- a/src/node/primitives/string.rs
+++ b/src/node/primitives/string.rs
@@ -18,9 +18,8 @@ impl NodeMeta for StringNode {
     const DEFAULT_VALUE: DefaultValue = DefaultValue::String("Hello");
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for StringNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let node_data = ctx.node_data.ok_or("Failed to get node data")?;
         ctx.output_writer.set(0, node_data)?;
         Ok(())

--- a/src/node/primitives/vector3.rs
+++ b/src/node/primitives/vector3.rs
@@ -28,9 +28,8 @@ impl NodeMeta for Vector3Node {
     };
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for Vector3Node {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let node_data = ctx.node_data.ok_or("Failed to get node data")?;
         ctx.output_writer.set(0, node_data)?;
         Ok(())

--- a/src/node/primitives/vertex.rs
+++ b/src/node/primitives/vertex.rs
@@ -29,9 +29,8 @@ impl NodeMeta for VertexNode {
     };
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for VertexNode {
-    async fn execute(&self, ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
         let node_data = ctx.node_data.ok_or("Failed to get node data")?;
         ctx.output_writer.set(0, node_data)?;
         Ok(())

--- a/src/node/subgraph/input_proxy.rs
+++ b/src/node/subgraph/input_proxy.rs
@@ -21,9 +21,8 @@ impl NodeMeta for SubGraphInputNode {
     const DEFAULT_VALUE: DefaultValue = DefaultValue::None;
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for SubGraphInputNode {
-    async fn execute(&self, _ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, _ctx: ExecutionContext) -> Result<(), String> {
         // Data is injected directly into outputs by SubGraphNode before execution.
         // This node's execute is a no-op.
         Ok(())

--- a/src/node/subgraph/mod.rs
+++ b/src/node/subgraph/mod.rs
@@ -510,17 +510,18 @@ impl SubGraphNode {
         Ok(())
     }
 
-    /// Execute the SubGraphNode with mutable access.
+    /// Execute the SubGraphNode synchronously with mutable access.
     ///
-    /// Called by the parent graph's execution engine, which holds a write lock
-    /// on the node entity. This allows mutable access to the internal graph
-    /// for execution, which is not possible from `NodeImpl::execute(&self)`.
+    /// Called by the parent graph's sync execution engine, which holds a
+    /// write lock on the node entity. This allows mutable access to the
+    /// internal graph for recursive execution, which is not possible from
+    /// `NodeImpl::execute(&self)`.
     ///
     /// Performs the full execution cycle:
     /// 1. Inject external inputs into the internal input proxy
-    /// 2. Execute the internal graph
+    /// 2. Execute the internal graph synchronously
     /// 3. Collect outputs from the internal output proxy
-    pub(crate) async fn execute_internal(
+    pub(crate) fn execute_internal_sync(
         &mut self,
         parent_node_id: &NodeId,
         parent_cache: SharedExecutionCache,
@@ -532,7 +533,15 @@ impl SubGraphNode {
         // This is needed because the internal graph doesn't know that
         // its proxy inputs changed.
         self.internal_graph.mark_all_nodes_dirty();
-        let _changes = self.internal_graph.execute().await?;
+        // Sync subgraph path requires a sync-only internal graph
+        // (plan-14c §SubGraphNode Policy phase 1). If the internal plan
+        // contains async nodes, surface that as a string error so the
+        // parent records it as a per-node execution failure rather than
+        // blocking on the internal async graph.
+        let _changes = self
+            .internal_graph
+            .execute_sync()
+            .map_err(|e| e.to_string())?;
         self.collect_outputs(parent_node_id, &parent_cache, &parent_node_states)?;
         Ok(())
     }
@@ -593,11 +602,10 @@ impl NodeMeta for SubGraphNode {
     const OUTPUTS: &'static [SlotDef] = &[];
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for SubGraphNode {
-    async fn execute(&self, _ctx: ExecutionContext) -> Result<(), String> {
-        // SubGraphNode execution is handled by execute_internal() which is called
-        // directly by the execution engine with the parent cache.
+    fn execute_sync(&self, _ctx: ExecutionContext) -> Result<(), String> {
+        // SubGraphNode execution is handled by execute_internal_sync() which is
+        // called directly by the sync execution engine with the parent cache.
         // This NodeImpl::execute() is not called for SubGraphNode.
         Ok(())
     }
@@ -647,8 +655,8 @@ mod tests {
     use super::*;
     use crate::{NodeGraphRead, NodeGraphWrite};
 
-    #[tokio::test]
-    async fn test_subgraph_creation() {
+    #[test]
+    fn test_subgraph_creation() {
         let mut graph = NodeGraph::new().expect("Failed to create graph");
         let subgraph_id = graph
             .create_node::<SubGraphNode>()
@@ -664,8 +672,8 @@ mod tests {
         assert_eq!(ns.output_slot_count(&subgraph_id), 0);
     }
 
-    #[tokio::test]
-    async fn test_subgraph_has_proxies() {
+    #[test]
+    fn test_subgraph_has_proxies() {
         let subgraph = SubGraphNode::new("Test").expect("Failed to create subgraph");
         assert!(subgraph
             .internal_graph

--- a/src/node/subgraph/output_proxy.rs
+++ b/src/node/subgraph/output_proxy.rs
@@ -21,9 +21,8 @@ impl NodeMeta for SubGraphOutputNode {
     const DEFAULT_VALUE: DefaultValue = DefaultValue::None;
 }
 
-#[async_trait::async_trait]
 impl NodeImpl for SubGraphOutputNode {
-    async fn execute(&self, _ctx: ExecutionContext) -> Result<(), String> {
+    fn execute_sync(&self, _ctx: ExecutionContext) -> Result<(), String> {
         // This node simply holds input data that was written by internal nodes.
         // SubGraphNode reads the data from this node's inputs after execution.
         Ok(())

--- a/src/node_graph/convenience.rs
+++ b/src/node_graph/convenience.rs
@@ -56,8 +56,8 @@ impl NodeGraph {
 mod tests {
     use crate::NodeGraphWrite;
 
-    #[tokio::test]
-    async fn test_node_ids() {
+    #[test]
+    fn test_node_ids() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         assert!(graph.node_ids().is_empty());
 
@@ -74,8 +74,8 @@ mod tests {
         assert!(ids.contains(&id2));
     }
 
-    #[tokio::test]
-    async fn test_edges_info() {
+    #[test]
+    fn test_edges_info() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let num = graph
             .create_node::<crate::NumberNode>()
@@ -95,8 +95,8 @@ mod tests {
         assert_eq!(edges[0].to_input, 0);
     }
 
-    #[tokio::test]
-    async fn test_edge_info() {
+    #[test]
+    fn test_edge_info() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let num = graph
             .create_node::<crate::NumberNode>()

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -1,16 +1,83 @@
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
+    fmt,
     sync::Arc,
 };
 
 use std::any::TypeId;
 
 use crate::{
-    node_graph_system::NodeGraphSystem, ColorValue, Data, DataType, DataValue, Edge, EdgeId,
-    ErrorTarget, ExecutionContext, GraphError, NodeEntity, NodeGraph, NodeId, NodeImpl, NodeMeta,
-    OutputWriter, SharedExecutionCache, SharedNodeStates, SubGraphNode, Vector3,
+    node_graph_system::NodeGraphSystem, BoxNodeFuture, ColorValue, Data, DataType, DataValue, Edge,
+    EdgeId, ErrorTarget, ExecutionContext, GraphError, NodeEntity, NodeExecutionKind, NodeGraph,
+    NodeId, NodeImpl, NodeMeta, OutputWriter, SharedExecutionCache, SharedNodeStates, SubGraphNode,
+    Vector3,
 };
+
+/// Typed error returned by `NodeGraph::execute_sync` and `execute_async`.
+///
+/// `RequiresAsyncExecution` is the load-bearing variant: it lets a sync
+/// caller distinguish "this graph contains async I/O nodes — call
+/// `execute_async`" from genuine planning or execution failure. Per
+/// plan-14c the dirty-state contract requires that returning this error
+/// must NOT clear the changed-node set, so a follow-up `execute_async`
+/// can run the same plan.
+#[derive(Debug, Clone)]
+pub enum GraphExecutionError {
+    /// The dirty plan contains one or more `AsyncIo` nodes; the sync
+    /// kernel cannot run them. Re-run via `execute_async`. Dirty state
+    /// is preserved so the async re-run sees the same plan.
+    RequiresAsyncExecution { node_ids: Vec<NodeId> },
+    /// The execution plan could not be built (e.g. lock poisoning,
+    /// topological cycle, missing graph metadata).
+    PlanningFailed(String),
+    /// One of the node executions failed in a way the planner cannot
+    /// retry from. Per-node execution failures are recorded separately
+    /// inside `ExecutionResult` and do NOT raise this variant.
+    ExecutionFailed(String),
+}
+
+impl fmt::Display for GraphExecutionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RequiresAsyncExecution { node_ids } => write!(
+                f,
+                "graph contains {} AsyncIo node(s); call `execute_async` instead",
+                node_ids.len()
+            ),
+            Self::PlanningFailed(msg) => write!(f, "graph planning failed: {msg}"),
+            Self::ExecutionFailed(msg) => write!(f, "graph execution failed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for GraphExecutionError {}
+
+/// Topologically sorted execution plan plus the dirty set it was built
+/// from. The planner snapshots the changed-node set without draining
+/// it, so a `RequiresAsyncExecution` rejection leaves the graph
+/// re-executable from the same dirty state.
+struct ExecutionPlan {
+    /// Snapshot of nodes that were dirty when the plan was built. The
+    /// executor drains the underlying `NodeStates::changed_nodes` only
+    /// after API validation succeeds.
+    dirty_nodes: HashSet<NodeId>,
+    /// Topologically grouped node levels — same-level nodes have no
+    /// data dependencies on each other and may run in parallel.
+    levels: Vec<Vec<NodeId>>,
+    /// Flattened executed-node list in topological order, for output
+    /// collection.
+    executed_node_ids: Vec<NodeId>,
+    /// Removed nodes drained from bookkeeping at plan time (they don't
+    /// participate in execution but are reported in `ExecutionResult`).
+    removed_nodes: Vec<NodeId>,
+}
+
+impl ExecutionPlan {
+    fn is_empty(&self) -> bool {
+        self.executed_node_ids.is_empty()
+    }
+}
 
 /// Execution event for progress tracking during graph execution.
 #[derive(Debug, Clone)]
@@ -536,6 +603,27 @@ impl NodeGraphWrite for NodeGraph {
     }
 }
 
+/// Look up a node's execution kind (`SyncCpu` / `AsyncIo`) by `NodeId`.
+///
+/// Used by the planner to decide whether the dirty plan can run on the
+/// sync kernel or requires `execute_async`. Locks the nodes map briefly,
+/// then holds a read lock on the node entity only long enough to call
+/// `execution_kind()` (a cheap method that does not touch I/O).
+fn node_execution_kind(
+    node_id: &NodeId,
+    shared_nodes: &crate::SharedNodes,
+) -> Option<NodeExecutionKind> {
+    let entity = {
+        let guard = shared_nodes.lock().ok()?;
+        guard.get(node_id).map(Arc::clone)?
+    };
+    let read = match entity.read() {
+        Ok(r) => r,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    Some(read.execution_kind())
+}
+
 /// Execute a single node synchronously.
 ///
 /// Locks the nodes map only long enough to clone out the node entity, then
@@ -599,9 +687,11 @@ fn execute_node_sync(
                     Err(poisoned) => poisoned.into_inner(),
                 };
                 match build_execution_context(&node_id, shared_node_states, shared_cache) {
-                    Ok(ctx) => node_read.execute(ctx),
+                    Ok(ctx) => node_read.execute_sync(ctx),
                     Err(e) => Err(e),
                 }
+                // node_read drops at end of branch — locks released
+                // before the next level starts.
             }
         }));
 
@@ -629,31 +719,37 @@ fn execute_node_sync(
 }
 
 impl NodeGraph {
-    /// Execute the graph synchronously with the default mode (`Parallel`).
+    // === Public synchronous API ===========================================
+
+    /// Execute the dirty graph synchronously with the default scheduling
+    /// mode (`Parallel`).
     ///
-    /// This is the canonical execution kernel. It does not depend on any
-    /// async runtime — callers may invoke it from event handlers, reactive
-    /// effects, or async test contexts without nested executor coordination.
+    /// Returns `RequiresAsyncExecution` (without losing dirty state) if
+    /// the planned graph contains any `NodeExecutionKind::AsyncIo` nodes.
+    /// In that case, call [`execute_async`](Self::execute_async).
     ///
-    /// Returns `ExecutionResult` containing outputs from computed nodes,
-    /// edge values, execution errors, and IDs of removed nodes.
-    pub fn execute_sync(&self) -> Result<ExecutionResult, String> {
+    /// Per plan-14c the synchronous kernel never enters an async runtime
+    /// and never calls `block_on`. It is safe to invoke from a UI event
+    /// handler, a reactive effect, a Tokio task, or a sync test.
+    pub fn execute_sync(&self) -> Result<ExecutionResult, GraphExecutionError> {
         self.execute_sync_with_progress(ExecutionMode::default(), |_| {})
     }
 
-    /// Execute the graph synchronously with the requested scheduling mode.
-    pub fn execute_sync_with_mode(&self, mode: ExecutionMode) -> Result<ExecutionResult, String> {
+    /// Execute the dirty graph synchronously with the requested mode.
+    pub fn execute_sync_with_mode(
+        &self,
+        mode: ExecutionMode,
+    ) -> Result<ExecutionResult, GraphExecutionError> {
         self.execute_sync_with_progress(mode, |_| {})
     }
 
-    /// Execute the graph synchronously with the requested scheduling mode
-    /// and a progress callback that fires per node as it starts, completes,
-    /// or fails.
+    /// Execute the dirty graph synchronously with the requested mode and
+    /// a per-node progress callback.
     pub fn execute_sync_with_progress<F>(
         &self,
         mode: ExecutionMode,
         on_progress: F,
-    ) -> Result<ExecutionResult, String>
+    ) -> Result<ExecutionResult, GraphExecutionError>
     where
         F: Fn(ExecutionEvent) + Send + Sync + 'static,
     {
@@ -661,64 +757,104 @@ impl NodeGraph {
         self.execute_sync_inner(mode, on_progress)
     }
 
-    /// Backward-compatible async facade. Returns the same value as
-    /// [`execute_sync`]; the future is immediately ready and is not bound
-    /// to any async runtime.
-    pub async fn execute(&self) -> Result<ExecutionResult, String> {
-        self.execute_sync()
+    // === Public asynchronous API ==========================================
+
+    /// Execute the dirty graph asynchronously with the default scheduling
+    /// mode (`Parallel`).
+    ///
+    /// Supports mixed `SyncCpu` + `AsyncIo` graphs. Sync nodes run on a
+    /// CPU executor (rayon in `Parallel`, the calling thread in
+    /// `Sequential`); async nodes return a `'static` future from
+    /// `prepare_async` and are awaited concurrently within each
+    /// topological level. Locks are dropped before any `.await`.
+    pub async fn execute_async(&self) -> Result<ExecutionResult, GraphExecutionError> {
+        self.execute_async_with_progress(ExecutionMode::default(), |_| {})
+            .await
     }
 
-    /// Backward-compatible async facade for [`execute_sync_with_progress`]
-    /// with `ExecutionMode::Parallel`.
-    pub async fn execute_with_progress<F>(&self, on_progress: F) -> Result<ExecutionResult, String>
+    /// Async variant of [`execute_sync_with_mode`].
+    pub async fn execute_async_with_mode(
+        &self,
+        mode: ExecutionMode,
+    ) -> Result<ExecutionResult, GraphExecutionError> {
+        self.execute_async_with_progress(mode, |_| {}).await
+    }
+
+    /// Async variant of [`execute_sync_with_progress`].
+    pub async fn execute_async_with_progress<F>(
+        &self,
+        mode: ExecutionMode,
+        on_progress: F,
+    ) -> Result<ExecutionResult, GraphExecutionError>
     where
         F: Fn(ExecutionEvent) + Send + Sync + 'static,
     {
-        self.execute_sync_with_progress(ExecutionMode::default(), on_progress)
+        let on_progress: Arc<dyn Fn(ExecutionEvent) + Send + Sync> = Arc::new(on_progress);
+        self.execute_async_inner(mode, on_progress).await
     }
 
-    fn execute_sync_inner(
+    // === Backward-compatible async API ====================================
+
+    /// Backward-compatible async entry point. Routes to the real async
+    /// executor (not a sync wrapper). Existing call sites that write
+    /// `graph.execute().await` continue to work.
+    pub async fn execute(&self) -> Result<ExecutionResult, GraphExecutionError> {
+        self.execute_async_with_mode(ExecutionMode::default()).await
+    }
+
+    /// Backward-compatible progress variant.
+    pub async fn execute_with_progress<F>(
         &self,
-        mode: ExecutionMode,
-        on_progress: Arc<dyn Fn(ExecutionEvent) + Send + Sync>,
-    ) -> Result<ExecutionResult, String> {
-        // Drain removed list from bookkeeping
+        on_progress: F,
+    ) -> Result<ExecutionResult, GraphExecutionError>
+    where
+        F: Fn(ExecutionEvent) + Send + Sync + 'static,
+    {
+        self.execute_async_with_progress(ExecutionMode::default(), on_progress)
+            .await
+    }
+
+    // === Planning =========================================================
+
+    /// Build the dirty execution plan WITHOUT clearing the changed-node
+    /// set.
+    ///
+    /// Snapshots `NodeStates::changed_nodes` via peek (not drain), runs a
+    /// BFS to collect downstream-affected nodes, and topologically sorts
+    /// the result. Removed nodes are drained from bookkeeping at plan
+    /// time — they don't participate in execution and are merely reported
+    /// in `ExecutionResult`, so eager drainage is safe.
+    fn build_execution_plan(&self) -> Result<ExecutionPlan, GraphExecutionError> {
         let removed = {
-            let mut b = self.bookkeeping.lock().map_err(|e| e.to_string())?;
+            let mut b = self
+                .bookkeeping
+                .lock()
+                .map_err(|e| GraphExecutionError::PlanningFailed(e.to_string()))?;
             std::mem::take(&mut b.removed_since_last_execute)
         };
 
-        // Drain changed nodes from NodeStates
         let changed = {
-            let mut ns = self.node_states.write().map_err(|e| e.to_string())?;
-            ns.drain_changed_nodes()
-        }; // write lock dropped
-
-        tracing::debug!(
-            target: "graph",
-            "[cognet] execute_sync: changed={} removed={} mode={:?}",
-            changed.len(),
-            removed.len(),
-            mode,
-        );
-
-        if changed.is_empty() && removed.is_empty() {
-            return Ok(ExecutionResult::empty());
-        }
+            let ns = self
+                .node_states
+                .read()
+                .map_err(|e| GraphExecutionError::PlanningFailed(e.to_string()))?;
+            ns.peek_changed_nodes()
+        };
 
         if changed.is_empty() {
-            return Ok(ExecutionResult {
+            return Ok(ExecutionPlan {
+                dirty_nodes: HashSet::new(),
+                levels: Vec::new(),
+                executed_node_ids: Vec::new(),
                 removed_nodes: removed,
-                ..Default::default()
             });
         }
 
-        // Clear previous execution errors before running
-        self.clear_execution_errors();
-
-        // BFS: changed nodes → all downstream nodes
         let dirty_nodes: HashSet<NodeId> = {
-            let ns = self.node_states.read().map_err(|e| e.to_string())?;
+            let ns = self
+                .node_states
+                .read()
+                .map_err(|e| GraphExecutionError::PlanningFailed(e.to_string()))?;
             let mut affected = HashSet::new();
             let mut queue: VecDeque<NodeId> = changed.into_iter().collect();
             while let Some(node_id) = queue.pop_front() {
@@ -735,61 +871,84 @@ impl NodeGraph {
             affected
         };
 
-        let sorted_node_levels = self.topological_sort(&dirty_nodes)?;
+        let levels = self
+            .topological_sort(&dirty_nodes)
+            .map_err(GraphExecutionError::PlanningFailed)?;
 
-        // Collect all node IDs that will be executed (for output collection)
-        let executed_node_ids: Vec<NodeId> = sorted_node_levels
+        let executed_node_ids: Vec<NodeId> = levels
             .iter()
             .flat_map(|level| level.iter().copied())
             .collect();
 
+        Ok(ExecutionPlan {
+            dirty_nodes,
+            levels,
+            executed_node_ids,
+            removed_nodes: removed,
+        })
+    }
+
+    /// Validate that the plan can run on the synchronous kernel.
+    ///
+    /// Returns `RequiresAsyncExecution { node_ids }` listing every dirty
+    /// node whose `execution_kind` is `AsyncIo`. The dirty set is
+    /// preserved so a subsequent `execute_async` call sees the same plan.
+    fn validate_for_sync(&self, plan: &ExecutionPlan) -> Result<(), GraphExecutionError> {
         let shared_nodes = self.node_manager.nodes();
+        let async_nodes: Vec<NodeId> = plan
+            .executed_node_ids
+            .iter()
+            .filter(|id| {
+                node_execution_kind(id, &shared_nodes)
+                    .map(|k| k == NodeExecutionKind::AsyncIo)
+                    .unwrap_or(false)
+            })
+            .copied()
+            .collect();
+        if async_nodes.is_empty() {
+            Ok(())
+        } else {
+            Err(GraphExecutionError::RequiresAsyncExecution {
+                node_ids: async_nodes,
+            })
+        }
+    }
+
+    /// Drain the changed-nodes set after planning + validation succeeded.
+    ///
+    /// This is the moment the plan transitions from "tentative" to
+    /// "in-flight": failures after this point are recorded as per-node
+    /// execution errors inside the returned `ExecutionResult`, not as a
+    /// graph-level `GraphExecutionError`.
+    fn commit_plan_drain(&self) -> Result<(), GraphExecutionError> {
+        let mut ns = self
+            .node_states
+            .write()
+            .map_err(|e| GraphExecutionError::ExecutionFailed(e.to_string()))?;
+        let _ = ns.drain_changed_nodes();
+        Ok(())
+    }
+
+    fn empty_result_with_removed(plan: &ExecutionPlan) -> ExecutionResult {
+        ExecutionResult {
+            removed_nodes: plan.removed_nodes.clone(),
+            ..Default::default()
+        }
+    }
+
+    /// Collect outputs/edge_values/errors for the executed plan.
+    fn collect_outputs(&self, plan: &ExecutionPlan) -> ExecutionResult {
         let shared_cache = self.cache.share();
         let shared_node_states = self.node_states.clone();
+        let executed_node_ids = &plan.executed_node_ids;
 
-        for level_nodes in sorted_node_levels {
-            let level_results: Vec<(NodeId, Result<(), String>)> = match mode {
-                ExecutionMode::Sequential => level_nodes
-                    .into_iter()
-                    .map(|node_id| {
-                        execute_node_sync(
-                            node_id,
-                            &shared_nodes,
-                            &shared_cache,
-                            &shared_node_states,
-                            on_progress.as_ref(),
-                        )
-                    })
-                    .collect(),
-                ExecutionMode::Parallel => level_nodes
-                    .into_par_iter()
-                    .map(|node_id| {
-                        execute_node_sync(
-                            node_id,
-                            &shared_nodes,
-                            &shared_cache,
-                            &shared_node_states,
-                            on_progress.as_ref(),
-                        )
-                    })
-                    .collect(),
-            };
-
-            for (node_id, res) in level_results {
-                if let Err(msg) = res {
-                    self.add_error(GraphError::execution(node_id, msg));
-                }
-            }
-        }
-
-        // Collect outputs from executed nodes (Arc-shared for zero-copy)
         let mut outputs = Vec::new();
         let mut node_outputs: HashMap<NodeId, Vec<Option<Data>>> = HashMap::new();
         let mut edge_values: HashMap<EdgeId, EdgeValue> = HashMap::new();
 
         if let Ok(ns) = shared_node_states.read() {
             if let Ok(cache) = shared_cache.read() {
-                for node_id in &executed_node_ids {
+                for node_id in executed_node_ids {
                     let output_count = ns.output_slot_count(node_id);
                     let mut slot_outputs = vec![None; output_count];
                     for (idx, slot_out) in slot_outputs.iter_mut().enumerate() {
@@ -805,8 +964,6 @@ impl NodeGraph {
                         }
                     }
 
-                    // For sink nodes (0 outputs), resolve input values via edges
-                    // so display/output nodes can show their received values.
                     if output_count == 0 {
                         let input_count = ns.input_slot_count(node_id);
                         let mut slot_inputs = vec![None; input_count];
@@ -825,7 +982,6 @@ impl NodeGraph {
                     }
                 }
 
-                // Build edge values from all edges involving executed nodes
                 for (edge_id, edge) in ns.edges() {
                     if executed_node_ids.contains(&edge.from_node_id) {
                         let data = cache
@@ -847,7 +1003,6 @@ impl NodeGraph {
             }
         }
 
-        // Extract execution errors for nodes
         let mut errors: HashMap<NodeId, NodeError> = HashMap::new();
         let all_errors = self.errors();
         for (target, err) in &all_errors {
@@ -863,13 +1018,240 @@ impl NodeGraph {
             }
         }
 
-        Ok(ExecutionResult {
+        ExecutionResult {
             node_outputs,
             edge_values,
             errors,
-            removed_nodes: removed,
+            removed_nodes: plan.removed_nodes.clone(),
             outputs,
-        })
+        }
+    }
+
+    // === Internal sync executor ===========================================
+
+    fn execute_sync_inner(
+        &self,
+        mode: ExecutionMode,
+        on_progress: Arc<dyn Fn(ExecutionEvent) + Send + Sync>,
+    ) -> Result<ExecutionResult, GraphExecutionError> {
+        let plan = self.build_execution_plan()?;
+
+        tracing::debug!(
+            target: "graph",
+            "[cognet] execute_sync: dirty={} removed={} mode={:?}",
+            plan.dirty_nodes.len(),
+            plan.removed_nodes.len(),
+            mode,
+        );
+
+        if plan.is_empty() {
+            return Ok(if plan.removed_nodes.is_empty() {
+                ExecutionResult::empty()
+            } else {
+                Self::empty_result_with_removed(&plan)
+            });
+        }
+
+        // Validate BEFORE clearing dirty state. RequiresAsyncExecution
+        // returns the dirty set intact for a follow-up `execute_async`.
+        self.validate_for_sync(&plan)?;
+
+        self.commit_plan_drain()?;
+        self.clear_execution_errors();
+
+        let shared_nodes = self.node_manager.nodes();
+        let shared_cache = self.cache.share();
+        let shared_node_states = self.node_states.clone();
+
+        for level_nodes in &plan.levels {
+            let level_vec: Vec<NodeId> = level_nodes.clone();
+            let level_results: Vec<(NodeId, Result<(), String>)> = match mode {
+                ExecutionMode::Sequential => level_vec
+                    .into_iter()
+                    .map(|node_id| {
+                        execute_node_sync(
+                            node_id,
+                            &shared_nodes,
+                            &shared_cache,
+                            &shared_node_states,
+                            on_progress.as_ref(),
+                        )
+                    })
+                    .collect(),
+                ExecutionMode::Parallel => level_vec
+                    .into_par_iter()
+                    .map(|node_id| {
+                        execute_node_sync(
+                            node_id,
+                            &shared_nodes,
+                            &shared_cache,
+                            &shared_node_states,
+                            on_progress.as_ref(),
+                        )
+                    })
+                    .collect(),
+            };
+
+            for (node_id, res) in level_results {
+                if let Err(msg) = res {
+                    self.add_error(GraphError::execution(node_id, msg));
+                }
+            }
+        }
+
+        Ok(self.collect_outputs(&plan))
+    }
+
+    // === Internal async executor ==========================================
+
+    async fn execute_async_inner(
+        &self,
+        mode: ExecutionMode,
+        on_progress: Arc<dyn Fn(ExecutionEvent) + Send + Sync>,
+    ) -> Result<ExecutionResult, GraphExecutionError> {
+        let plan = self.build_execution_plan()?;
+
+        tracing::debug!(
+            target: "graph",
+            "[cognet] execute_async: dirty={} removed={} mode={:?}",
+            plan.dirty_nodes.len(),
+            plan.removed_nodes.len(),
+            mode,
+        );
+
+        if plan.is_empty() {
+            return Ok(if plan.removed_nodes.is_empty() {
+                ExecutionResult::empty()
+            } else {
+                Self::empty_result_with_removed(&plan)
+            });
+        }
+
+        self.commit_plan_drain()?;
+        self.clear_execution_errors();
+
+        let shared_nodes = self.node_manager.nodes();
+        let shared_cache = self.cache.share();
+        let shared_node_states = self.node_states.clone();
+
+        for level_nodes in &plan.levels {
+            // Partition dirty level into Sync/Async by execution_kind.
+            let mut sync_ids: Vec<NodeId> = Vec::new();
+            let mut async_ids: Vec<NodeId> = Vec::new();
+            for &id in level_nodes {
+                match node_execution_kind(&id, &shared_nodes) {
+                    Some(NodeExecutionKind::AsyncIo) => async_ids.push(id),
+                    // Missing entity falls through to the sync path —
+                    // execute_node_sync records a per-node error.
+                    _ => sync_ids.push(id),
+                }
+            }
+
+            // Sync CPU work: rayon in Parallel, sequential otherwise.
+            // Note: this is sync work running inside an async fn. The
+            // caller's runtime can offload via `spawn_blocking` if it
+            // dislikes that — the plan-14c invariant is only that the
+            // graph executor itself never calls `block_on`.
+            let sync_results: Vec<(NodeId, Result<(), String>)> = match mode {
+                ExecutionMode::Sequential => sync_ids
+                    .into_iter()
+                    .map(|node_id| {
+                        execute_node_sync(
+                            node_id,
+                            &shared_nodes,
+                            &shared_cache,
+                            &shared_node_states,
+                            on_progress.as_ref(),
+                        )
+                    })
+                    .collect(),
+                ExecutionMode::Parallel => sync_ids
+                    .into_par_iter()
+                    .map(|node_id| {
+                        execute_node_sync(
+                            node_id,
+                            &shared_nodes,
+                            &shared_cache,
+                            &shared_node_states,
+                            on_progress.as_ref(),
+                        )
+                    })
+                    .collect(),
+            };
+
+            for (node_id, res) in &sync_results {
+                if let Err(msg) = res {
+                    self.add_error(GraphError::execution(*node_id, msg.clone()));
+                }
+            }
+
+            // Async I/O work: prepare each future under a short read
+            // lock, drop the lock, then await all futures concurrently.
+            // The lock-across-await invariant from plan-14c §Locking
+            // Rule lives here.
+            let mut async_futs = Vec::with_capacity(async_ids.len());
+            for node_id in async_ids {
+                on_progress(ExecutionEvent::Started(node_id));
+
+                let prep_result: Result<BoxNodeFuture, String> = {
+                    let entity = {
+                        let guard = match shared_nodes.lock() {
+                            Ok(g) => g,
+                            Err(_) => {
+                                self.add_error(GraphError::execution(
+                                    node_id,
+                                    "Lock poisoned".to_string(),
+                                ));
+                                continue;
+                            }
+                        };
+                        guard.get(&node_id).map(Arc::clone)
+                    };
+                    match entity {
+                        None => Err("node entity missing".to_string()),
+                        Some(node_entity) => {
+                            let read = match node_entity.read() {
+                                Ok(r) => r,
+                                Err(p) => p.into_inner(),
+                            };
+                            // `read` (the RwLockReadGuard) is dropped at
+                            // the end of this match arm — strictly BEFORE
+                            // we await the prepared future, which is the
+                            // plan-14c lock-across-await invariant.
+                            match build_execution_context(
+                                &node_id,
+                                &shared_node_states,
+                                &shared_cache,
+                            ) {
+                                Ok(ctx) => read.prepare_async(ctx),
+                                Err(e) => Err(e),
+                            }
+                        }
+                    }
+                };
+
+                async_futs.push(async move {
+                    match prep_result {
+                        Ok(fut) => (node_id, fut.await),
+                        Err(e) => (node_id, Err(e)),
+                    }
+                });
+            }
+
+            let async_results = futures::future::join_all(async_futs).await;
+
+            for (node_id, res) in async_results {
+                match res {
+                    Ok(()) => on_progress(ExecutionEvent::Completed(node_id)),
+                    Err(msg) => {
+                        on_progress(ExecutionEvent::Failed(node_id, msg.clone()));
+                        self.add_error(GraphError::execution(node_id, msg));
+                    }
+                }
+            }
+        }
+
+        Ok(self.collect_outputs(&plan))
     }
 }
 
@@ -877,6 +1259,8 @@ impl NodeGraph {
 mod sync_executor_tests {
     use super::*;
     use crate::{AddNode, NumberNode, SubGraphNode};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc as StdArc;
 
     /// Build a small `(a + b)` graph and return its three node ids.
     fn build_add_graph(a: f64, b: f64) -> (NodeGraph, NodeId, NodeId, NodeId) {
@@ -986,6 +1370,212 @@ mod sync_executor_tests {
             Poll::Pending => panic!("compat facade must be immediately ready"),
         };
         assert_eq!(output_for(&result, add_id), 6.0);
+    }
+
+    // ============================================================
+    // Plan-14c: hybrid sync/async execution tests
+    // ============================================================
+
+    /// Test-only `AsyncIo` node. Captures `node_data` under the short
+    /// read lock that `prepare_async` holds, returns a `'static` future
+    /// that yields once (proving the executor actually `.awaits` it),
+    /// then forwards the value to its output. No node entity guard is
+    /// held across `.await` — that is the plan-14c lock invariant.
+    #[derive(Debug)]
+    pub struct AsyncEchoNode;
+
+    impl crate::NodeMeta for AsyncEchoNode {
+        const NAME: &'static str = "AsyncEcho";
+        const CATEGORY: crate::NodeCategory = crate::NodeCategory::Primitive;
+        const INPUTS: &'static [crate::SlotDef] = &[];
+        const OUTPUTS: &'static [crate::SlotDef] = &[crate::SlotDef {
+            label: "Out",
+            data_type: crate::DataType::Number,
+            max_connections: None,
+        }];
+        const DEFAULT_VALUE: crate::DefaultValue = crate::DefaultValue::Number(42.0);
+    }
+
+    impl NodeImpl for AsyncEchoNode {
+        fn execution_kind(&self) -> NodeExecutionKind {
+            NodeExecutionKind::AsyncIo
+        }
+
+        fn prepare_async(&self, ctx: ExecutionContext) -> Result<BoxNodeFuture, String> {
+            // Move the value out of the (lock-bound) ctx into the
+            // 'static future. The executor drops the read lock before
+            // awaiting this future.
+            let data = ctx.node_data;
+            let writer = ctx.output_writer;
+            Ok(Box::pin(async move {
+                tokio::task::yield_now().await;
+                let value = data.ok_or_else(|| "AsyncEcho: missing node_data".to_string())?;
+                writer.set(0, value)?;
+                Ok(())
+            }))
+        }
+    }
+
+    crate::register_nodes!(AsyncEchoNode);
+
+    #[test]
+    fn execute_sync_returns_requires_async_for_async_node() {
+        // Graph: sync NumberNode (0) -> async AsyncEchoNode (downstream).
+        // The async node sits in the dirty plan, so execute_sync must
+        // refuse with RequiresAsyncExecution and PRESERVE the dirty set.
+        let mut graph = NodeGraph::new().unwrap();
+        let echo_id = graph.create_node::<AsyncEchoNode>().unwrap();
+
+        let err = graph.execute_sync().expect_err("sync rejects async plan");
+        match err {
+            GraphExecutionError::RequiresAsyncExecution { node_ids } => {
+                assert!(
+                    node_ids.contains(&echo_id),
+                    "error must list the async node"
+                );
+            }
+            other => panic!("expected RequiresAsyncExecution, got {other:?}"),
+        }
+
+        // Dirty preservation: the failed sync call must NOT have
+        // drained `changed_nodes`. A second `execute_sync` returns the
+        // same error and (more importantly) the same dirty set.
+        let err2 = graph
+            .execute_sync()
+            .expect_err("dirty plan still rejects on second call");
+        assert!(matches!(
+            err2,
+            GraphExecutionError::RequiresAsyncExecution { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn execute_async_runs_async_node_value_propagates() {
+        let mut graph = NodeGraph::new().unwrap();
+        let echo_id = graph.create_node::<AsyncEchoNode>().unwrap();
+        graph
+            .update_node_data(&echo_id, Data::new(7.5_f64).unwrap())
+            .unwrap();
+
+        let result = graph
+            .execute_async()
+            .await
+            .expect("async executor handles async nodes");
+        assert_eq!(output_for(&result, echo_id), 7.5);
+    }
+
+    #[tokio::test]
+    async fn execute_async_handles_mixed_sync_async_levels() {
+        // Two sync sources feed an async sink (AsyncEcho doesn't read
+        // upstream — but we sequence dirty so both kinds appear).
+        let mut graph = NodeGraph::new().unwrap();
+        let n1 = graph.create_node::<NumberNode>().unwrap();
+        let n2 = graph.create_node::<NumberNode>().unwrap();
+        let add_id = graph.create_node::<AddNode>().unwrap();
+        let echo_id = graph.create_node::<AsyncEchoNode>().unwrap();
+
+        graph
+            .update_node_data(&n1, Data::new(2.0_f64).unwrap())
+            .unwrap();
+        graph
+            .update_node_data(&n2, Data::new(5.0_f64).unwrap())
+            .unwrap();
+        graph
+            .update_node_data(&echo_id, Data::new(11.0_f64).unwrap())
+            .unwrap();
+        graph.connect_nodes(&n1, 0, &add_id, 0).unwrap();
+        graph.connect_nodes(&n2, 0, &add_id, 1).unwrap();
+
+        let result = graph.execute_async().await.expect("mixed graph runs");
+        assert_eq!(output_for(&result, add_id), 7.0);
+        assert_eq!(output_for(&result, echo_id), 11.0);
+    }
+
+    #[tokio::test]
+    async fn async_executor_drops_locks_before_awaiting_node_future() {
+        // While the AsyncEcho future is suspended (yield_now), other
+        // threads/tasks must be able to acquire READ locks on the graph.
+        // We exercise this by reading `get_output_value` from another
+        // task while the async execution is in flight.
+        //
+        // The test would deadlock if execute_async held a graph or node
+        // lock across `.await` — that's the plan-14c lock-invariant
+        // canary.
+        let mut graph = NodeGraph::new().unwrap();
+        let echo_id = graph.create_node::<AsyncEchoNode>().unwrap();
+        graph
+            .update_node_data(&echo_id, Data::new(99.0_f64).unwrap())
+            .unwrap();
+
+        let arc_graph = StdArc::new(graph);
+        let g_for_reader = StdArc::clone(&arc_graph);
+        let probe = tokio::spawn(async move {
+            // Ten attempts to read while execution is running. Each
+            // call hits the node-states / cache locks that the
+            // executor would otherwise be holding.
+            let mut got_some = false;
+            for _ in 0..10 {
+                tokio::task::yield_now().await;
+                if g_for_reader.get_output_value(&echo_id, 0).is_some() {
+                    got_some = true;
+                }
+            }
+            got_some
+        });
+
+        let result = arc_graph
+            .execute_async()
+            .await
+            .expect("async executor completes despite concurrent reads");
+        assert_eq!(output_for(&result, echo_id), 99.0);
+        let _ = probe.await;
+    }
+
+    #[tokio::test]
+    async fn async_executor_ran_async_node_count() {
+        // Also confirm that prepare_async was invoked exactly once per
+        // dirty async node. We use a process-global counter because the
+        // node struct itself is unit-sized.
+        static PREPARE_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+        #[derive(Debug)]
+        struct CountingAsyncNode;
+
+        impl crate::NodeMeta for CountingAsyncNode {
+            const NAME: &'static str = "CountingAsync";
+            const CATEGORY: crate::NodeCategory = crate::NodeCategory::Primitive;
+            const INPUTS: &'static [crate::SlotDef] = &[];
+            const OUTPUTS: &'static [crate::SlotDef] = &[crate::SlotDef {
+                label: "Out",
+                data_type: crate::DataType::Number,
+                max_connections: None,
+            }];
+            const DEFAULT_VALUE: crate::DefaultValue = crate::DefaultValue::Number(0.0);
+        }
+
+        impl NodeImpl for CountingAsyncNode {
+            fn execution_kind(&self) -> NodeExecutionKind {
+                NodeExecutionKind::AsyncIo
+            }
+            fn prepare_async(&self, ctx: ExecutionContext) -> Result<BoxNodeFuture, String> {
+                PREPARE_CALLS.fetch_add(1, Ordering::SeqCst);
+                let writer = ctx.output_writer;
+                let data = ctx.node_data;
+                Ok(Box::pin(async move {
+                    let value = data.unwrap_or(Data::new(0.0_f64).unwrap());
+                    writer.set(0, value)?;
+                    Ok(())
+                }))
+            }
+        }
+
+        crate::register_nodes!(CountingAsyncNode);
+
+        let mut graph = NodeGraph::new().unwrap();
+        let _id = graph.create_node::<CountingAsyncNode>().unwrap();
+        PREPARE_CALLS.store(0, Ordering::SeqCst);
+        graph.execute_async().await.expect("async run");
+        assert_eq!(PREPARE_CALLS.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -1,9 +1,3 @@
-#[cfg(not(target_arch = "wasm32"))]
-use tokio::{runtime::Handle, task};
-
-#[cfg(target_arch = "wasm32")]
-use futures::future::join_all;
-
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -27,6 +21,24 @@ pub enum ExecutionEvent {
     Completed(NodeId),
     /// Node execution failed with an error.
     Failed(NodeId, String),
+}
+
+/// Execution scheduling mode for `NodeGraph::execute_sync_with_mode`.
+///
+/// All variants are synchronous — the difference is only in how nodes within
+/// the same topological level are scheduled.
+///
+/// `Parallel` is the recommended default on native targets. On targets where
+/// rayon's worker pool is not initialised (notably wasm without
+/// `wasm-bindgen-rayon` setup), rayon transparently falls back to sequential
+/// execution, so `Parallel` is safe everywhere.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionMode {
+    /// Execute nodes one at a time in stable topological order.
+    Sequential,
+    /// Execute same-level nodes in parallel via rayon (best-effort).
+    #[default]
+    Parallel,
 }
 
 /// Output from a single node execution.
@@ -524,26 +536,152 @@ impl NodeGraphWrite for NodeGraph {
     }
 }
 
-impl NodeGraph {
-    /// Execute the graph asynchronously.
-    ///
-    /// Returns `ExecutionResult` containing outputs from computed nodes,
-    /// edge values, execution errors, and IDs of removed nodes.
-    pub async fn execute(&self) -> Result<ExecutionResult, String> {
-        self.execute_with_progress(|_| {}).await
+/// Execute a single node synchronously.
+///
+/// Locks the nodes map only long enough to clone out the node entity, then
+/// holds a read lock on the entity for regular nodes (allowing concurrent
+/// reads from UI) and upgrades to a write lock for `SubGraphNode` (which
+/// needs `&mut self` to drive its internal graph).
+///
+/// Wraps execution in `catch_unwind` so a single node panic does not abort
+/// the surrounding rayon level.
+fn execute_node_sync(
+    node_id: NodeId,
+    shared_nodes: &crate::SharedNodes,
+    shared_cache: &SharedExecutionCache,
+    shared_node_states: &SharedNodeStates,
+    on_progress: &(dyn Fn(ExecutionEvent) + Send + Sync),
+) -> (NodeId, Result<(), String>) {
+    on_progress(ExecutionEvent::Started(node_id));
+
+    let result: Result<(), String> = {
+        let entity = {
+            let nodes_guard = match shared_nodes.lock() {
+                Ok(g) => g,
+                Err(_) => {
+                    on_progress(ExecutionEvent::Failed(node_id, "Lock poisoned".to_string()));
+                    return (node_id, Err("Lock poisoned".to_string()));
+                }
+            };
+            nodes_guard.get(&node_id).map(Arc::clone)
+        };
+
+        let Some(node_entity) = entity else {
+            on_progress(ExecutionEvent::Completed(node_id));
+            return (node_id, Ok(()));
+        };
+
+        // Identify SubGraphNode under a read lock first to decide whether we
+        // need the write lock. Most nodes are regular and never need it.
+        let is_subgraph = match node_entity.read() {
+            Ok(r) => r.as_any().downcast_ref::<SubGraphNode>().is_some(),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .as_any()
+                .downcast_ref::<SubGraphNode>()
+                .is_some(),
+        };
+
+        let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if is_subgraph {
+                let mut node_write = match node_entity.write() {
+                    Ok(w) => w,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                let sg = node_write
+                    .as_any_mut()
+                    .downcast_mut::<SubGraphNode>()
+                    .expect("downcast verified above");
+                sg.execute_internal_sync(&node_id, shared_cache.share(), shared_node_states.clone())
+            } else {
+                let node_read = match node_entity.read() {
+                    Ok(r) => r,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                match build_execution_context(&node_id, shared_node_states, shared_cache) {
+                    Ok(ctx) => node_read.execute(ctx),
+                    Err(e) => Err(e),
+                }
+            }
+        }));
+
+        match panic_result {
+            Ok(res) => res,
+            Err(panic_payload) => {
+                let msg = if let Some(s) = panic_payload.downcast_ref::<&str>() {
+                    format!("Node panicked: {s}")
+                } else if let Some(s) = panic_payload.downcast_ref::<String>() {
+                    format!("Node panicked: {s}")
+                } else {
+                    "Node panicked".to_string()
+                };
+                Err(msg)
+            }
+        }
+    };
+
+    match &result {
+        Ok(()) => on_progress(ExecutionEvent::Completed(node_id)),
+        Err(msg) => on_progress(ExecutionEvent::Failed(node_id, msg.clone())),
     }
 
-    /// Execute the graph with progress callback.
+    (node_id, result)
+}
+
+impl NodeGraph {
+    /// Execute the graph synchronously with the default mode (`Parallel`).
     ///
-    /// The callback is called for each node as it starts executing,
-    /// completes, or fails. This enables real-time UI updates.
+    /// This is the canonical execution kernel. It does not depend on any
+    /// async runtime — callers may invoke it from event handlers, reactive
+    /// effects, or async test contexts without nested executor coordination.
     ///
     /// Returns `ExecutionResult` containing outputs from computed nodes,
     /// edge values, execution errors, and IDs of removed nodes.
+    pub fn execute_sync(&self) -> Result<ExecutionResult, String> {
+        self.execute_sync_with_progress(ExecutionMode::default(), |_| {})
+    }
+
+    /// Execute the graph synchronously with the requested scheduling mode.
+    pub fn execute_sync_with_mode(&self, mode: ExecutionMode) -> Result<ExecutionResult, String> {
+        self.execute_sync_with_progress(mode, |_| {})
+    }
+
+    /// Execute the graph synchronously with the requested scheduling mode
+    /// and a progress callback that fires per node as it starts, completes,
+    /// or fails.
+    pub fn execute_sync_with_progress<F>(
+        &self,
+        mode: ExecutionMode,
+        on_progress: F,
+    ) -> Result<ExecutionResult, String>
+    where
+        F: Fn(ExecutionEvent) + Send + Sync + 'static,
+    {
+        let on_progress: Arc<dyn Fn(ExecutionEvent) + Send + Sync> = Arc::new(on_progress);
+        self.execute_sync_inner(mode, on_progress)
+    }
+
+    /// Backward-compatible async facade. Returns the same value as
+    /// [`execute_sync`]; the future is immediately ready and is not bound
+    /// to any async runtime.
+    pub async fn execute(&self) -> Result<ExecutionResult, String> {
+        self.execute_sync()
+    }
+
+    /// Backward-compatible async facade for [`execute_sync_with_progress`]
+    /// with `ExecutionMode::Parallel`.
     pub async fn execute_with_progress<F>(&self, on_progress: F) -> Result<ExecutionResult, String>
     where
         F: Fn(ExecutionEvent) + Send + Sync + 'static,
     {
+        self.execute_sync_with_progress(ExecutionMode::default(), on_progress)
+    }
+
+    fn execute_sync_inner(
+        &self,
+        mode: ExecutionMode,
+        on_progress: Arc<dyn Fn(ExecutionEvent) + Send + Sync>,
+    ) -> Result<ExecutionResult, String> {
         // Drain removed list from bookkeeping
         let removed = {
             let mut b = self.bookkeeping.lock().map_err(|e| e.to_string())?;
@@ -558,9 +696,10 @@ impl NodeGraph {
 
         tracing::debug!(
             target: "graph",
-            "[cognet] execute: changed={} removed={}",
+            "[cognet] execute_sync: changed={} removed={} mode={:?}",
             changed.len(),
             removed.len(),
+            mode,
         );
 
         if changed.is_empty() && removed.is_empty() {
@@ -607,202 +746,38 @@ impl NodeGraph {
         let shared_nodes = self.node_manager.nodes();
         let shared_cache = self.cache.share();
         let shared_node_states = self.node_states.clone();
-        let on_progress = Arc::new(on_progress);
 
-        #[cfg(target_arch = "wasm32")]
-        {
-            for level_nodes in sorted_node_levels {
-                let futures: Vec<_> = level_nodes
+        for level_nodes in sorted_node_levels {
+            let level_results: Vec<(NodeId, Result<(), String>)> = match mode {
+                ExecutionMode::Sequential => level_nodes
                     .into_iter()
                     .map(|node_id| {
-                        let shared_nodes = shared_nodes.share();
-                        let shared_cache = shared_cache.share();
-                        let shared_node_states = shared_node_states.clone();
-                        let on_progress = Arc::clone(&on_progress);
-                        async move {
-                            on_progress(ExecutionEvent::Started(node_id));
-
-                            let result = {
-                                let nodes_guard = match shared_nodes.lock() {
-                                    Ok(g) => g,
-                                    Err(_) => return (node_id, Err("Lock poisoned".to_string())),
-                                };
-                                if let Some(node) = nodes_guard.get(&node_id) {
-                                    let node_clone = Arc::clone(node);
-                                    drop(nodes_guard);
-                                    // Read lock for regular nodes (allows concurrent UI reads).
-                                    // SubGraphNode upgrades to write lock (needs &mut self).
-                                    let node_read = match node_clone.read() {
-                                        Ok(r) => r,
-                                        Err(poisoned) => poisoned.into_inner(),
-                                    };
-                                    if node_read.as_any().downcast_ref::<SubGraphNode>().is_some() {
-                                        drop(node_read);
-                                        let mut node_write = match node_clone.write() {
-                                            Ok(w) => w,
-                                            Err(poisoned) => poisoned.into_inner(),
-                                        };
-                                        let sg = node_write
-                                            .as_any_mut()
-                                            .downcast_mut::<SubGraphNode>()
-                                            .expect("downcast verified above");
-                                        sg.execute_internal(
-                                            &node_id,
-                                            shared_cache.share(),
-                                            shared_node_states.clone(),
-                                        )
-                                        .await
-                                    } else {
-                                        match build_execution_context(
-                                            &node_id,
-                                            &shared_node_states,
-                                            &shared_cache,
-                                        ) {
-                                            Ok(ctx) => node_read.execute(ctx).await,
-                                            Err(e) => Err(e),
-                                        }
-                                    }
-                                } else {
-                                    Ok(())
-                                }
-                            };
-
-                            match &result {
-                                Ok(()) => on_progress(ExecutionEvent::Completed(node_id)),
-                                Err(msg) => {
-                                    on_progress(ExecutionEvent::Failed(node_id, msg.clone()))
-                                }
-                            }
-
-                            (node_id, result)
-                        }
+                        execute_node_sync(
+                            node_id,
+                            &shared_nodes,
+                            &shared_cache,
+                            &shared_node_states,
+                            on_progress.as_ref(),
+                        )
                     })
-                    .collect();
+                    .collect(),
+                ExecutionMode::Parallel => level_nodes
+                    .into_par_iter()
+                    .map(|node_id| {
+                        execute_node_sync(
+                            node_id,
+                            &shared_nodes,
+                            &shared_cache,
+                            &shared_node_states,
+                            on_progress.as_ref(),
+                        )
+                    })
+                    .collect(),
+            };
 
-                let results = join_all(futures).await;
-                for (node_id, res) in results {
-                    if let Err(msg) = res {
-                        self.add_error(GraphError::execution(node_id, msg));
-                    }
-                }
-            }
-        }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let rt_handle = Arc::new(Handle::current());
-            for level_nodes in sorted_node_levels {
-                let results: Vec<(NodeId, Result<(), String>)> = task::spawn_blocking({
-                    let shared_nodes = shared_nodes.share();
-                    let shared_cache = shared_cache.share();
-                    let shared_node_states = shared_node_states.clone();
-                    let rt_handle = Arc::clone(&rt_handle);
-                    let on_progress = Arc::clone(&on_progress);
-                    move || {
-                        level_nodes
-                            .into_par_iter()
-                            .map(|node_id| {
-                                on_progress(ExecutionEvent::Started(node_id));
-
-                                let result = {
-                                    let nodes_guard = match shared_nodes.lock() {
-                                        Ok(g) => g,
-                                        Err(_) => {
-                                            return (node_id, Err("Lock poisoned".to_string()))
-                                        }
-                                    };
-                                    if let Some(node) = nodes_guard.get(&node_id) {
-                                        let node_clone = Arc::clone(node);
-                                        let cache_clone = shared_cache.share();
-                                        let ns_clone = shared_node_states.clone();
-                                        let rt_clone = Arc::clone(&rt_handle);
-                                        drop(nodes_guard);
-                                        // Catch panics so a single node failure
-                                        // doesn't abort the entire execution level.
-                                        match std::panic::catch_unwind(
-                                            std::panic::AssertUnwindSafe(|| {
-                                                #[allow(clippy::await_holding_lock)]
-                                                rt_clone.block_on(async {
-                                                    // Read lock for regular nodes; write for SubGraphNode.
-                                                    let node_read = match node_clone.read() {
-                                                        Ok(r) => r,
-                                                        Err(poisoned) => poisoned.into_inner(),
-                                                    };
-                                                    if node_read
-                                                        .as_any()
-                                                        .downcast_ref::<SubGraphNode>()
-                                                        .is_some()
-                                                    {
-                                                        drop(node_read);
-                                                        let mut node_write = match node_clone
-                                                            .write()
-                                                        {
-                                                            Ok(w) => w,
-                                                            Err(poisoned) => poisoned.into_inner(),
-                                                        };
-                                                        let sg = node_write
-                                                            .as_any_mut()
-                                                            .downcast_mut::<SubGraphNode>()
-                                                            .expect("downcast verified above");
-                                                        sg.execute_internal(
-                                                            &node_id,
-                                                            cache_clone,
-                                                            ns_clone,
-                                                        )
-                                                        .await
-                                                    } else {
-                                                        match build_execution_context(
-                                                            &node_id,
-                                                            &ns_clone,
-                                                            &cache_clone,
-                                                        ) {
-                                                            Ok(ctx) => node_read.execute(ctx).await,
-                                                            Err(e) => Err(e),
-                                                        }
-                                                    }
-                                                })
-                                            }),
-                                        ) {
-                                            Ok(result) => result,
-                                            Err(panic_payload) => {
-                                                let msg = if let Some(s) =
-                                                    panic_payload.downcast_ref::<&str>()
-                                                {
-                                                    format!("Node panicked: {}", s)
-                                                } else if let Some(s) =
-                                                    panic_payload.downcast_ref::<String>()
-                                                {
-                                                    format!("Node panicked: {}", s)
-                                                } else {
-                                                    "Node panicked".to_string()
-                                                };
-                                                Err(msg)
-                                            }
-                                        }
-                                    } else {
-                                        Ok(())
-                                    }
-                                };
-
-                                match &result {
-                                    Ok(()) => on_progress(ExecutionEvent::Completed(node_id)),
-                                    Err(msg) => {
-                                        on_progress(ExecutionEvent::Failed(node_id, msg.clone()))
-                                    }
-                                }
-
-                                (node_id, result)
-                            })
-                            .collect()
-                    }
-                })
-                .await
-                .map_err(|e| e.to_string())?;
-
-                for (node_id, res) in results {
-                    if let Err(msg) = res {
-                        self.add_error(GraphError::execution(node_id, msg));
-                    }
+            for (node_id, res) in level_results {
+                if let Err(msg) = res {
+                    self.add_error(GraphError::execution(node_id, msg));
                 }
             }
         }
@@ -895,5 +870,166 @@ impl NodeGraph {
             removed_nodes: removed,
             outputs,
         })
+    }
+}
+
+#[cfg(test)]
+mod sync_executor_tests {
+    use super::*;
+    use crate::{AddNode, NumberNode, SubGraphNode};
+
+    /// Build a small `(a + b)` graph and return its three node ids.
+    fn build_add_graph(a: f64, b: f64) -> (NodeGraph, NodeId, NodeId, NodeId) {
+        let mut graph = NodeGraph::new().unwrap();
+        let a_id = graph.create_node::<NumberNode>().unwrap();
+        let b_id = graph.create_node::<NumberNode>().unwrap();
+        let add_id = graph.create_node::<AddNode>().unwrap();
+
+        graph
+            .update_node_data(&a_id, Data::new(a).unwrap())
+            .unwrap();
+        graph
+            .update_node_data(&b_id, Data::new(b).unwrap())
+            .unwrap();
+        graph.connect_nodes(&a_id, 0, &add_id, 0).unwrap();
+        graph.connect_nodes(&b_id, 0, &add_id, 1).unwrap();
+
+        (graph, a_id, b_id, add_id)
+    }
+
+    fn output_for(result: &ExecutionResult, node_id: NodeId) -> f64 {
+        result
+            .node_outputs
+            .get(&node_id)
+            .and_then(|slots| slots.first().cloned().flatten())
+            .and_then(|d| d.value::<f64>().ok().copied())
+            .expect("node output present")
+    }
+
+    #[test]
+    fn sequential_matches_parallel_on_independent_levels() {
+        // Two parallel sub-additions feed into a final add.
+        let mut graph = NodeGraph::new().unwrap();
+        let n1 = graph.create_node::<NumberNode>().unwrap();
+        let n2 = graph.create_node::<NumberNode>().unwrap();
+        let n3 = graph.create_node::<NumberNode>().unwrap();
+        let n4 = graph.create_node::<NumberNode>().unwrap();
+        let add_left = graph.create_node::<AddNode>().unwrap();
+        let add_right = graph.create_node::<AddNode>().unwrap();
+        let add_top = graph.create_node::<AddNode>().unwrap();
+
+        graph
+            .update_node_data(&n1, Data::new(1.0_f64).unwrap())
+            .unwrap();
+        graph
+            .update_node_data(&n2, Data::new(2.0_f64).unwrap())
+            .unwrap();
+        graph
+            .update_node_data(&n3, Data::new(3.0_f64).unwrap())
+            .unwrap();
+        graph
+            .update_node_data(&n4, Data::new(4.0_f64).unwrap())
+            .unwrap();
+        graph.connect_nodes(&n1, 0, &add_left, 0).unwrap();
+        graph.connect_nodes(&n2, 0, &add_left, 1).unwrap();
+        graph.connect_nodes(&n3, 0, &add_right, 0).unwrap();
+        graph.connect_nodes(&n4, 0, &add_right, 1).unwrap();
+        graph.connect_nodes(&add_left, 0, &add_top, 0).unwrap();
+        graph.connect_nodes(&add_right, 0, &add_top, 1).unwrap();
+
+        let seq = graph
+            .execute_sync_with_mode(ExecutionMode::Sequential)
+            .unwrap();
+        let seq_top = output_for(&seq, add_top);
+
+        // Mark all dirty so a second execute recomputes the same nodes.
+        graph.mark_all_nodes_dirty();
+        let par = graph
+            .execute_sync_with_mode(ExecutionMode::Parallel)
+            .unwrap();
+        let par_top = output_for(&par, add_top);
+
+        assert_eq!(seq_top, 10.0);
+        assert_eq!(par_top, 10.0);
+    }
+
+    #[test]
+    fn execute_sync_produces_expected_value() {
+        let (graph, _, _, add_id) = build_add_graph(7.0, 8.0);
+        let result = graph.execute_sync().unwrap();
+        assert_eq!(output_for(&result, add_id), 15.0);
+    }
+
+    #[test]
+    fn async_execute_facade_returns_same_value() {
+        // The async execute() is a thin wrapper that does not require any
+        // runtime — `block_on` from `pollster` would also work, but since the
+        // future is immediately ready we can poll it inline with a noop waker.
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+        const VTABLE: RawWakerVTable = RawWakerVTable::new(
+            |_| RawWaker::new(std::ptr::null(), &VTABLE),
+            |_| {},
+            |_| {},
+            |_| {},
+        );
+        let raw = RawWaker::new(std::ptr::null(), &VTABLE);
+        let waker = unsafe { Waker::from_raw(raw) };
+        let mut cx = Context::from_waker(&waker);
+
+        let (graph, _, _, add_id) = build_add_graph(2.5, 3.5);
+        let mut fut = Box::pin(graph.execute());
+        let result = match Pin::new(&mut fut).poll(&mut cx) {
+            Poll::Ready(r) => r.unwrap(),
+            Poll::Pending => panic!("compat facade must be immediately ready"),
+        };
+        assert_eq!(output_for(&result, add_id), 6.0);
+    }
+
+    #[test]
+    fn subgraph_executes_recursively_through_sync_kernel() {
+        let mut graph = NodeGraph::new().unwrap();
+        let outer_a = graph.create_node::<NumberNode>().unwrap();
+        let outer_b = graph.create_node::<NumberNode>().unwrap();
+        graph
+            .update_node_data(&outer_a, Data::new(11.0_f64).unwrap())
+            .unwrap();
+        graph
+            .update_node_data(&outer_b, Data::new(31.0_f64).unwrap())
+            .unwrap();
+
+        // Build a subgraph that sums two inputs.
+        let sub_id = graph.create_node::<SubGraphNode>().unwrap();
+        graph
+            .add_subgraph_input(&sub_id, "A", DataType::Number)
+            .unwrap();
+        graph
+            .add_subgraph_input(&sub_id, "B", DataType::Number)
+            .unwrap();
+        graph
+            .add_subgraph_output(&sub_id, "Sum", DataType::Number)
+            .unwrap();
+
+        let (in_proxy, out_proxy) = graph.subgraph_proxy_ids(&sub_id).unwrap();
+        let inner_add = graph
+            .with_subgraph_mut(&sub_id, |internal| {
+                let inner_add = internal.create_node::<AddNode>().unwrap();
+                internal.connect_nodes(&in_proxy, 0, &inner_add, 0).unwrap();
+                internal.connect_nodes(&in_proxy, 1, &inner_add, 1).unwrap();
+                internal
+                    .connect_nodes(&inner_add, 0, &out_proxy, 0)
+                    .unwrap();
+                inner_add
+            })
+            .unwrap();
+        let _ = inner_add; // value unused after construction; only for clarity
+
+        graph.connect_nodes(&outer_a, 0, &sub_id, 0).unwrap();
+        graph.connect_nodes(&outer_b, 0, &sub_id, 1).unwrap();
+
+        let result = graph.execute_sync().unwrap();
+        assert_eq!(output_for(&result, sub_id), 42.0);
     }
 }

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -28,6 +28,15 @@ pub enum GraphExecutionError {
     /// kernel cannot run them. Re-run via `execute_async`. Dirty state
     /// is preserved so the async re-run sees the same plan.
     RequiresAsyncExecution { node_ids: Vec<NodeId> },
+    /// The dirty plan contains one or more `SubGraphNode`s whose
+    /// internal graph has `AsyncIo` nodes. Plan-14c phase 1 does not
+    /// yet implement async subgraph execution — that requires
+    /// refactoring `SubGraphNode` so the parent executor can drop its
+    /// write lock across the internal `.await`. Returned from BOTH
+    /// `execute_sync` and `execute_async` (the latter because we don't
+    /// want to silently block on the internal async graph). Dirty
+    /// state is preserved.
+    RequiresAsyncSubgraphSupport { subgraph_node_ids: Vec<NodeId> },
     /// The execution plan could not be built (e.g. lock poisoning,
     /// topological cycle, missing graph metadata).
     PlanningFailed(String),
@@ -44,6 +53,12 @@ impl fmt::Display for GraphExecutionError {
                 f,
                 "graph contains {} AsyncIo node(s); call `execute_async` instead",
                 node_ids.len()
+            ),
+            Self::RequiresAsyncSubgraphSupport { subgraph_node_ids } => write!(
+                f,
+                "graph contains {} SubGraphNode(s) with AsyncIo internal nodes; \
+                 async subgraph execution is not yet supported in plan-14c phase 1",
+                subgraph_node_ids.len()
             ),
             Self::PlanningFailed(msg) => write!(f, "graph planning failed: {msg}"),
             Self::ExecutionFailed(msg) => write!(f, "graph execution failed: {msg}"),
@@ -624,6 +639,68 @@ fn node_execution_kind(
     Some(read.execution_kind())
 }
 
+/// Walk the planned dirty set; if any `SubGraphNode` has `AsyncIo`
+/// nodes in its internal graph, return
+/// `RequiresAsyncSubgraphSupport` listing the parent subgraph IDs.
+/// Used by both sync + async validators.
+fn validate_async_subgraphs(
+    executed_ids: &[NodeId],
+    shared_nodes: &crate::SharedNodes,
+) -> Result<(), GraphExecutionError> {
+    let async_subgraphs: Vec<NodeId> = executed_ids
+        .iter()
+        .filter(|id| subgraph_internal_has_async(id, shared_nodes))
+        .copied()
+        .collect();
+    if async_subgraphs.is_empty() {
+        Ok(())
+    } else {
+        Err(GraphExecutionError::RequiresAsyncSubgraphSupport {
+            subgraph_node_ids: async_subgraphs,
+        })
+    }
+}
+
+/// Inspect a `SubGraphNode`'s internal graph for `AsyncIo` nodes.
+///
+/// Returns true iff the node at `sg_id` is a `SubGraphNode` and its
+/// internal graph contains at least one node with
+/// `NodeExecutionKind::AsyncIo`. Used by both validators (sync + async
+/// subgraph) to surface a typed error rather than silently blocking on
+/// the internal async graph.
+fn subgraph_internal_has_async(sg_id: &NodeId, shared_nodes: &crate::SharedNodes) -> bool {
+    let entity = {
+        let Ok(guard) = shared_nodes.lock() else {
+            return false;
+        };
+        let Some(e) = guard.get(sg_id) else {
+            return false;
+        };
+        Arc::clone(e)
+    };
+    let read = match entity.read() {
+        Ok(r) => r,
+        Err(p) => p.into_inner(),
+    };
+    let Some(sg) = read.as_any().downcast_ref::<SubGraphNode>() else {
+        return false;
+    };
+    let internal_nodes = sg.internal_graph().node_manager.nodes();
+    let Ok(internal_guard) = internal_nodes.lock() else {
+        return false;
+    };
+    for inner in internal_guard.values() {
+        let inner_read = match inner.read() {
+            Ok(r) => r,
+            Err(p) => p.into_inner(),
+        };
+        if inner_read.execution_kind() == NodeExecutionKind::AsyncIo {
+            return true;
+        }
+    }
+    false
+}
+
 /// Execute a single node synchronously.
 ///
 /// Locks the nodes map only long enough to clone out the node entity, then
@@ -890,11 +967,22 @@ impl NodeGraph {
 
     /// Validate that the plan can run on the synchronous kernel.
     ///
-    /// Returns `RequiresAsyncExecution { node_ids }` listing every dirty
-    /// node whose `execution_kind` is `AsyncIo`. The dirty set is
-    /// preserved so a subsequent `execute_async` call sees the same plan.
+    /// Two failure modes, each returning a typed error WITHOUT draining
+    /// the dirty set so the caller can re-plan:
+    ///
+    /// - `RequiresAsyncSubgraphSupport` — a dirty `SubGraphNode` has
+    ///   `AsyncIo` nodes inside its internal graph. Plan-14c phase 1
+    ///   does not yet drive the internal graph through
+    ///   `execute_async`, so neither sync NOR async kernels can run
+    ///   the plan. Reported with priority over plain
+    ///   `RequiresAsyncExecution` because the caller cannot recover
+    ///   simply by switching to `execute_async`.
+    /// - `RequiresAsyncExecution` — direct dirty `AsyncIo` nodes.
+    ///   Caller can switch to `execute_async`.
     fn validate_for_sync(&self, plan: &ExecutionPlan) -> Result<(), GraphExecutionError> {
         let shared_nodes = self.node_manager.nodes();
+        validate_async_subgraphs(&plan.executed_node_ids, &shared_nodes)?;
+
         let async_nodes: Vec<NodeId> = plan
             .executed_node_ids
             .iter()
@@ -912,6 +1000,18 @@ impl NodeGraph {
                 node_ids: async_nodes,
             })
         }
+    }
+
+    /// Validate that the plan can run on the asynchronous kernel.
+    ///
+    /// `execute_async` handles direct `AsyncIo` nodes natively, but
+    /// plan-14c phase 1 does not yet drive `SubGraphNode`'s internal
+    /// graph through `execute_async`. Reject early with a typed error
+    /// rather than silently propagating an internal
+    /// `RequiresAsyncExecution` as a per-node string failure.
+    fn validate_for_async(&self, plan: &ExecutionPlan) -> Result<(), GraphExecutionError> {
+        let shared_nodes = self.node_manager.nodes();
+        validate_async_subgraphs(&plan.executed_node_ids, &shared_nodes)
     }
 
     /// Drain the changed-nodes set after planning + validation succeeded.
@@ -1063,6 +1163,7 @@ impl NodeGraph {
         let shared_cache = self.cache.share();
         let shared_node_states = self.node_states.clone();
 
+        let mut failed_ids: HashSet<NodeId> = HashSet::new();
         for level_nodes in &plan.levels {
             let level_vec: Vec<NodeId> = level_nodes.clone();
             let level_results: Vec<(NodeId, Result<(), String>)> = match mode {
@@ -1094,12 +1195,38 @@ impl NodeGraph {
 
             for (node_id, res) in level_results {
                 if let Err(msg) = res {
+                    failed_ids.insert(node_id);
                     self.add_error(GraphError::execution(node_id, msg));
                 }
             }
         }
 
+        // Per plan-14c §Dirty-State Rule, failures must preserve enough
+        // dirty state for a later retry. Re-mark every failed node as
+        // changed so the next `execute_*` call replans from the same
+        // failure point. Successful nodes stay clean.
+        self.restore_dirty_for_failed(failed_ids);
+
         Ok(self.collect_outputs(&plan))
+    }
+
+    /// Re-mark `failed_ids` as changed in `NodeStates`. Idempotent if
+    /// the set is empty. Logs but does not propagate a poisoned-lock
+    /// error — the executor has already finished, so the worst case is
+    /// that a future caller sees a slightly stale dirty set.
+    fn restore_dirty_for_failed(&self, failed_ids: HashSet<NodeId>) {
+        if failed_ids.is_empty() {
+            return;
+        }
+        match self.node_states.write() {
+            Ok(mut ns) => ns.restore_changed_nodes(failed_ids),
+            Err(e) => tracing::warn!(
+                target: "graph",
+                err = %e,
+                "[cognet] could not restore dirty state for failed nodes; \
+                 NodeStates lock poisoned",
+            ),
+        }
     }
 
     // === Internal async executor ==========================================
@@ -1127,6 +1254,11 @@ impl NodeGraph {
             });
         }
 
+        // Validate BEFORE draining dirty so async-subgraph rejection
+        // preserves the dirty set for a later retry once async
+        // subgraph support lands.
+        self.validate_for_async(&plan)?;
+
         self.commit_plan_drain()?;
         self.clear_execution_errors();
 
@@ -1134,6 +1266,7 @@ impl NodeGraph {
         let shared_cache = self.cache.share();
         let shared_node_states = self.node_states.clone();
 
+        let mut failed_ids: HashSet<NodeId> = HashSet::new();
         for level_nodes in &plan.levels {
             // Partition dirty level into Sync/Async by execution_kind.
             let mut sync_ids: Vec<NodeId> = Vec::new();
@@ -1181,6 +1314,7 @@ impl NodeGraph {
 
             for (node_id, res) in &sync_results {
                 if let Err(msg) = res {
+                    failed_ids.insert(*node_id);
                     self.add_error(GraphError::execution(*node_id, msg.clone()));
                 }
             }
@@ -1245,11 +1379,16 @@ impl NodeGraph {
                     Ok(()) => on_progress(ExecutionEvent::Completed(node_id)),
                     Err(msg) => {
                         on_progress(ExecutionEvent::Failed(node_id, msg.clone()));
+                        failed_ids.insert(node_id);
                         self.add_error(GraphError::execution(node_id, msg));
                     }
                 }
             }
         }
+
+        // Per plan-14c §Dirty-State Rule: AsyncIo failures (transient
+        // remote errors etc.) must leave the dirty plan re-runnable.
+        self.restore_dirty_for_failed(failed_ids);
 
         Ok(self.collect_outputs(&plan))
     }
@@ -1577,6 +1716,242 @@ mod sync_executor_tests {
         graph.execute_async().await.expect("async run");
         assert_eq!(PREPARE_CALLS.load(Ordering::SeqCst), 1);
     }
+
+    // ============================================================
+    // Plan-14c finding 1: async subgraph typed error
+    // ============================================================
+
+    #[test]
+    fn execute_sync_returns_async_subgraph_support_for_inner_async_node() {
+        // Build a SubGraphNode whose internal graph contains an async
+        // node. execute_sync must reject with the specific
+        // RequiresAsyncSubgraphSupport variant — NOT a per-node string
+        // error from execute_internal_sync's inner failure path.
+        let mut graph = NodeGraph::new().unwrap();
+        let sub_id = graph.create_node::<SubGraphNode>().unwrap();
+        graph
+            .add_subgraph_output(&sub_id, "Out", DataType::Number)
+            .unwrap();
+        let (_in_proxy, out_proxy) = graph.subgraph_proxy_ids(&sub_id).unwrap();
+        graph
+            .with_subgraph_mut(&sub_id, |internal| {
+                let echo = internal.create_node::<AsyncEchoNode>().unwrap();
+                internal.connect_nodes(&echo, 0, &out_proxy, 0).unwrap();
+            })
+            .unwrap();
+
+        let err = graph
+            .execute_sync()
+            .expect_err("inner async should reject sync");
+        match err {
+            GraphExecutionError::RequiresAsyncSubgraphSupport { subgraph_node_ids } => {
+                assert!(subgraph_node_ids.contains(&sub_id));
+            }
+            other => panic!("expected RequiresAsyncSubgraphSupport, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_async_returns_async_subgraph_support_for_inner_async_node() {
+        // Plan-14c phase 1 explicitly does NOT yet implement async
+        // subgraph execution. The async kernel must surface that as a
+        // typed error rather than silently falling through to
+        // execute_internal_sync (which would block on the inner async
+        // graph or string-error per-node).
+        let mut graph = NodeGraph::new().unwrap();
+        let sub_id = graph.create_node::<SubGraphNode>().unwrap();
+        graph
+            .add_subgraph_output(&sub_id, "Out", DataType::Number)
+            .unwrap();
+        let (_in_proxy, out_proxy) = graph.subgraph_proxy_ids(&sub_id).unwrap();
+        graph
+            .with_subgraph_mut(&sub_id, |internal| {
+                let echo = internal.create_node::<AsyncEchoNode>().unwrap();
+                internal.connect_nodes(&echo, 0, &out_proxy, 0).unwrap();
+            })
+            .unwrap();
+
+        let err = graph
+            .execute_async()
+            .await
+            .expect_err("inner async should reject async too in phase 1");
+        assert!(matches!(
+            err,
+            GraphExecutionError::RequiresAsyncSubgraphSupport { .. }
+        ));
+    }
+
+    #[test]
+    fn execute_sync_async_subgraph_rejection_preserves_dirty_state() {
+        // The validation rejects BEFORE drain, so a follow-up
+        // execute_sync still sees the dirty plan (and still errors).
+        let mut graph = NodeGraph::new().unwrap();
+        let sub_id = graph.create_node::<SubGraphNode>().unwrap();
+        graph
+            .add_subgraph_output(&sub_id, "Out", DataType::Number)
+            .unwrap();
+        let (_in_proxy, out_proxy) = graph.subgraph_proxy_ids(&sub_id).unwrap();
+        graph
+            .with_subgraph_mut(&sub_id, |internal| {
+                let echo = internal.create_node::<AsyncEchoNode>().unwrap();
+                internal.connect_nodes(&echo, 0, &out_proxy, 0).unwrap();
+            })
+            .unwrap();
+
+        // First call rejects.
+        let _ = graph.execute_sync().expect_err("first reject");
+        // Dirty preserved → second call sees the same plan and rejects
+        // with the same variant.
+        let err2 = graph.execute_sync().expect_err("second reject");
+        assert!(matches!(
+            err2,
+            GraphExecutionError::RequiresAsyncSubgraphSupport { .. }
+        ));
+    }
+
+    // ============================================================
+    // Plan-14c finding 2: dirty preservation on per-node failure
+    // ============================================================
+
+    /// Test-only `AsyncIo` node that fails on a configurable counter.
+    /// Allows simulating a transient remote-API error and verifying
+    /// the dirty set is restored for retry.
+    #[derive(Debug)]
+    pub struct FlakyAsyncNode;
+
+    /// Number of remaining failures FlakyAsyncNode should produce
+    /// before succeeding. Decremented on each call.
+    static FLAKY_FAIL_REMAINING: AtomicUsize = AtomicUsize::new(0);
+
+    impl crate::NodeMeta for FlakyAsyncNode {
+        const NAME: &'static str = "FlakyAsync";
+        const CATEGORY: crate::NodeCategory = crate::NodeCategory::Primitive;
+        const INPUTS: &'static [crate::SlotDef] = &[];
+        const OUTPUTS: &'static [crate::SlotDef] = &[crate::SlotDef {
+            label: "Out",
+            data_type: crate::DataType::Number,
+            max_connections: None,
+        }];
+        const DEFAULT_VALUE: crate::DefaultValue = crate::DefaultValue::Number(0.0);
+    }
+
+    impl NodeImpl for FlakyAsyncNode {
+        fn execution_kind(&self) -> NodeExecutionKind {
+            NodeExecutionKind::AsyncIo
+        }
+
+        fn prepare_async(&self, ctx: ExecutionContext) -> Result<BoxNodeFuture, String> {
+            let writer = ctx.output_writer;
+            let data = ctx.node_data;
+            Ok(Box::pin(async move {
+                // Simulate a transient failure pattern: fail the first
+                // N attempts, succeed afterwards.
+                let prev = FLAKY_FAIL_REMAINING.fetch_sub(1, Ordering::SeqCst);
+                if prev > 0 {
+                    return Err("transient FlakyAsync failure (test fixture)".to_string());
+                }
+                let value = data.unwrap_or(Data::new(0.0_f64).unwrap());
+                writer.set(0, value)?;
+                Ok(())
+            }))
+        }
+    }
+
+    crate::register_nodes!(FlakyAsyncNode);
+
+    #[tokio::test]
+    async fn async_failure_preserves_dirty_for_retry() {
+        // Configure FlakyAsync to fail once. First execute_async
+        // returns Ok with a per-node error in the result; the failed
+        // node is re-marked dirty. A retry succeeds without manual
+        // re-marking.
+        FLAKY_FAIL_REMAINING.store(1, Ordering::SeqCst);
+
+        let mut graph = NodeGraph::new().unwrap();
+        let flaky_id = graph.create_node::<FlakyAsyncNode>().unwrap();
+        graph
+            .update_node_data(&flaky_id, Data::new(123.0_f64).unwrap())
+            .unwrap();
+
+        // First call: per-node error. Successful caller path.
+        let r1 = graph
+            .execute_async()
+            .await
+            .expect("execute_async itself does not fail on per-node errors");
+        assert!(
+            r1.errors.contains_key(&flaky_id),
+            "first run records per-node failure"
+        );
+        // Output absent because the node didn't write its value.
+        assert!(r1
+            .node_outputs
+            .get(&flaky_id)
+            .and_then(|s| s.first().cloned().flatten())
+            .is_none());
+
+        // Retry without re-mark: dirty preservation guarantees the
+        // failed node is in the dirty plan again.
+        let r2 = graph.execute_async().await.expect("retry succeeds");
+        assert!(
+            !r2.errors.contains_key(&flaky_id),
+            "retry produces no error"
+        );
+        assert_eq!(output_for(&r2, flaky_id), 123.0);
+    }
+
+    #[test]
+    fn sync_failure_preserves_dirty_for_retry() {
+        // Same dirty-preservation rule for sync nodes. Use a
+        // counter-driven sync node so the first execute_sync errors
+        // and the second succeeds.
+        SYNC_FAIL_REMAINING.store(1, Ordering::SeqCst);
+
+        let mut graph = NodeGraph::new().unwrap();
+        let id = graph.create_node::<FlakySyncNode>().unwrap();
+        graph
+            .update_node_data(&id, Data::new(7.0_f64).unwrap())
+            .unwrap();
+
+        let r1 = graph
+            .execute_sync()
+            .expect("graph-level Ok despite per-node err");
+        assert!(r1.errors.contains_key(&id));
+
+        let r2 = graph.execute_sync().expect("retry succeeds");
+        assert!(!r2.errors.contains_key(&id));
+        assert_eq!(output_for(&r2, id), 7.0);
+    }
+
+    #[derive(Debug)]
+    pub struct FlakySyncNode;
+
+    static SYNC_FAIL_REMAINING: AtomicUsize = AtomicUsize::new(0);
+
+    impl crate::NodeMeta for FlakySyncNode {
+        const NAME: &'static str = "FlakySync";
+        const CATEGORY: crate::NodeCategory = crate::NodeCategory::Primitive;
+        const INPUTS: &'static [crate::SlotDef] = &[];
+        const OUTPUTS: &'static [crate::SlotDef] = &[crate::SlotDef {
+            label: "Out",
+            data_type: crate::DataType::Number,
+            max_connections: None,
+        }];
+        const DEFAULT_VALUE: crate::DefaultValue = crate::DefaultValue::Number(0.0);
+    }
+
+    impl NodeImpl for FlakySyncNode {
+        fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
+            let prev = SYNC_FAIL_REMAINING.fetch_sub(1, Ordering::SeqCst);
+            if prev > 0 {
+                return Err("transient FlakySync failure (test fixture)".to_string());
+            }
+            let data = ctx.node_data.ok_or("missing data")?;
+            ctx.output_writer.set(0, data)?;
+            Ok(())
+        }
+    }
+
+    crate::register_nodes!(FlakySyncNode);
 
     #[test]
     fn subgraph_executes_recursively_through_sync_kernel() {

--- a/src/node_graph/node_state.rs
+++ b/src/node_graph/node_state.rs
@@ -433,4 +433,14 @@ impl NodeStates {
     pub fn drain_changed_nodes(&mut self) -> HashSet<NodeId> {
         std::mem::take(&mut self.changed_nodes)
     }
+
+    /// Snapshot the current changed-node set without clearing it.
+    ///
+    /// The plan-14c executor calls this during planning to validate the
+    /// dirty plan against the selected execution API. If validation
+    /// fails (e.g. sync execute on an async-required graph), the dirty
+    /// set must remain intact so a follow-up async run can re-plan.
+    pub fn peek_changed_nodes(&self) -> HashSet<NodeId> {
+        self.changed_nodes.clone()
+    }
 }

--- a/src/node_graph/node_state.rs
+++ b/src/node_graph/node_state.rs
@@ -443,4 +443,14 @@ impl NodeStates {
     pub fn peek_changed_nodes(&self) -> HashSet<NodeId> {
         self.changed_nodes.clone()
     }
+
+    /// Re-mark a set of nodes as changed.
+    ///
+    /// The plan-14c executor calls this after execution to restore
+    /// dirty state for nodes that failed (e.g. transient AsyncIo
+    /// errors), so a follow-up `execute_async` retry can re-run those
+    /// nodes against the same plan without losing the change record.
+    pub fn restore_changed_nodes(&mut self, ids: HashSet<NodeId>) {
+        self.changed_nodes.extend(ids);
+    }
 }

--- a/src/node_graph/path_navigation.rs
+++ b/src/node_graph/path_navigation.rs
@@ -131,8 +131,8 @@ where
 mod tests {
     use crate::NodeGraphWrite;
 
-    #[tokio::test]
-    async fn test_with_graph_at_path_empty() {
+    #[test]
+    fn test_with_graph_at_path_empty() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let num = graph
             .create_node::<crate::NumberNode>()
@@ -145,8 +145,8 @@ mod tests {
         assert!(ids.contains(&num));
     }
 
-    #[tokio::test]
-    async fn test_with_graph_at_path_single() {
+    #[test]
+    fn test_with_graph_at_path_single() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let sg = graph
             .create_node::<crate::SubGraphNode>()
@@ -165,8 +165,8 @@ mod tests {
         assert!(ids.contains(&internal_id));
     }
 
-    #[tokio::test]
-    async fn test_with_graph_at_path_mut() {
+    #[test]
+    fn test_with_graph_at_path_mut() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let sg = graph
             .create_node::<crate::SubGraphNode>()
@@ -185,8 +185,8 @@ mod tests {
         assert!(ids.contains(&id));
     }
 
-    #[tokio::test]
-    async fn test_node_ids_at_path() {
+    #[test]
+    fn test_node_ids_at_path() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let sg = graph
             .create_node::<crate::SubGraphNode>()
@@ -197,8 +197,8 @@ mod tests {
         assert!(ids.len() >= 2);
     }
 
-    #[tokio::test]
-    async fn test_edges_at_path() {
+    #[test]
+    fn test_edges_at_path() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let sg = graph
             .create_node::<crate::SubGraphNode>()
@@ -209,8 +209,8 @@ mod tests {
         assert!(edges.is_empty());
     }
 
-    #[tokio::test]
-    async fn test_is_subgraph_node_at_path() {
+    #[test]
+    fn test_is_subgraph_node_at_path() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let sg = graph
             .create_node::<crate::SubGraphNode>()

--- a/src/node_graph/subgraph_helpers.rs
+++ b/src/node_graph/subgraph_helpers.rs
@@ -262,6 +262,7 @@ impl NodeGraph {
     ///
     /// `target_node_id` and `target_slot` identify which internal node's
     /// multi-connection input slot the proxy outputs should connect to.
+    #[allow(clippy::too_many_arguments)]
     pub fn add_subgraph_dynamic_input(
         &self,
         node_id: &NodeId,
@@ -313,8 +314,8 @@ impl NodeGraph {
 mod tests {
     use crate::NodeGraphWrite;
 
-    #[tokio::test]
-    async fn test_is_subgraph_node() {
+    #[test]
+    fn test_is_subgraph_node() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let num = graph
             .create_node::<crate::NumberNode>()
@@ -327,8 +328,8 @@ mod tests {
         assert!(graph.is_subgraph_node(&sg));
     }
 
-    #[tokio::test]
-    async fn test_subgraph_label() {
+    #[test]
+    fn test_subgraph_label() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let sg = graph
             .create_node::<crate::SubGraphNode>()
@@ -339,8 +340,8 @@ mod tests {
         assert_eq!(graph.subgraph_label(&sg), Some("Custom".to_string()));
     }
 
-    #[tokio::test]
-    async fn test_subgraph_proxy_ids() {
+    #[test]
+    fn test_subgraph_proxy_ids() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let sg = graph
             .create_node::<crate::SubGraphNode>()
@@ -353,8 +354,8 @@ mod tests {
         assert!(internal_ids.contains(&output_id));
     }
 
-    #[tokio::test]
-    async fn test_add_remove_subgraph_ports() {
+    #[test]
+    fn test_add_remove_subgraph_ports() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let sg = graph
             .create_node::<crate::SubGraphNode>()
@@ -388,8 +389,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_with_subgraph() {
+    #[test]
+    fn test_with_subgraph() {
         let mut graph = crate::NodeGraph::new().expect("create graph");
         let sg = graph
             .create_node::<crate::SubGraphNode>()

--- a/src/node_graph/subgraph_ops.rs
+++ b/src/node_graph/subgraph_ops.rs
@@ -672,8 +672,8 @@ mod tests {
     use super::*;
     use crate::{NodeGraphRead, NodeGraphWrite};
 
-    #[tokio::test]
-    async fn test_group_and_ungroup() {
+    #[test]
+    fn test_group_and_ungroup() {
         let mut graph = NodeGraph::new().expect("Failed to create graph");
 
         // Create a simple chain: Number → Add → NumberOutput
@@ -726,8 +726,8 @@ mod tests {
         assert!(graph.get_node_by_id(&result.subgraph_node_id).is_none());
     }
 
-    #[tokio::test]
-    async fn test_group_empty_fails() {
+    #[test]
+    fn test_group_empty_fails() {
         let mut graph = NodeGraph::new().expect("Failed to create graph");
         let selected: HashSet<NodeId> = HashSet::new();
         assert!(graph.group_nodes(&selected, "Empty").is_err());
@@ -735,8 +735,8 @@ mod tests {
 
     /// Test that intermediate outputs (source slot also feeds internal nodes)
     /// are filtered out and not exposed as SubGraphNode ports.
-    #[tokio::test]
-    async fn test_group_filters_intermediate_outputs() {
+    #[test]
+    fn test_group_filters_intermediate_outputs() {
         let mut graph = NodeGraph::new().expect("Failed to create graph");
 
         // Graph: num1 → add → multiply → output
@@ -776,8 +776,8 @@ mod tests {
 
     /// Test terminal output detection: a node with no downstream consumers
     /// should automatically get an output port on the SubGraphNode.
-    #[tokio::test]
-    async fn test_group_terminal_output() {
+    #[test]
+    fn test_group_terminal_output() {
         let mut graph = NodeGraph::new().expect("Failed to create graph");
 
         // Graph: num1 → add (no downstream from add)
@@ -809,8 +809,8 @@ mod tests {
 
     /// Test source-based dedup: same source feeding multiple internal targets
     /// should produce only one input port with fan-out inside the subgraph.
-    #[tokio::test]
-    async fn test_group_source_dedup() {
+    #[test]
+    fn test_group_source_dedup() {
         let mut graph = NodeGraph::new().expect("Failed to create graph");
 
         // Graph: source → A.input0, source → B.input0


### PR DESCRIPTION
## Summary

Adds the executor side of plan-14c — a hybrid kernel that runs `SyncCpu` nodes via the configured CPU scheduler (rayon in `Parallel`, sequential otherwise) and awaits `AsyncIo` node futures concurrently within each topological level. Sync callers can branch on a typed `RequiresAsyncExecution { node_ids }` error to fall back to `execute_async`. The Revion side already depends on this API (PR AltrixHub/revion#183 merged but currently fails to compile against `develop` — this PR is the missing piece).

## Changes

- `NodeImpl` trait split: `execute_sync(&self, ctx)` for `SyncCpu` nodes, `prepare_async(&self, ctx) -> Result<BoxNodeFuture, String>` for `AsyncIo` nodes. `NodeExecutionKind { SyncCpu, AsyncIo }` capability metadata. All built-ins converted; `SyncCpu` is the default so existing implementations keep working without changes.
- Hybrid executor on `NodeGraph`: `execute_sync()` / `execute_sync_with_mode()` / `execute_sync_with_progress()` (synchronous CPU-only kernel) and `execute_async()` / `execute_async_with_mode()` / `execute_async_with_progress()` (hybrid). `execute()` / `execute_with_progress()` are kept as the backward-compatible async entry points.
- Typed errors: `enum GraphExecutionError { RequiresAsyncExecution, PlanningFailed, ExecutionFailed, RequiresAsyncSubgraphSupport }` with `Display` + `std::error::Error`. `validate_for_sync` rejects plans containing async nodes BEFORE the dirty set is drained, so a failed sync call preserves dirty state for a follow-up `execute_async`.
- Async subgraph guard: an inner `AsyncIo` node inside a `SubGraphNode` now surfaces as `RequiresAsyncSubgraphSupport { subgraph_node_ids }` rather than silently falling back to `execute_internal_sync`. Validation runs before drain, so a retry once async-subgraph support lands re-plans against the same dirty set.
- Dirty preservation on failure: `restore_dirty_for_failed()` re-marks every failed node as changed AFTER execution completes, so a transient `AsyncIo` failure (remote API timeout etc.) can be retried without manual re-mark.
- Locking invariant: async nodes are awaited only after the node read lock is dropped — `prepare_async` is called inside a short scope, the returned future is pushed to a per-level vector, then `futures::future::join_all` awaits them all with no guard held.
- Dependencies: restore `futures = "0.3"` (used by `join_all`); add `tokio` as a `dev-dependency` for `#[tokio::test]`. The cognet core no longer depends on `tokio` at runtime.

## Test plan

- [x] `cargo nextest run --workspace` — 36 passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] New tests cover: sync rejecting plans with async nodes, async-subgraph rejection preserving dirty state, sync/async transient-failure retry without manual re-mark.
- [ ] Verify Revion `develop` compiles end-to-end against this branch (once merged into cognet `develop` the path-dep in Revion picks it up automatically).