### PR TITLE
feat(node-manager): runtime-named factory APIs for pillar-2 variant templates

### DIFF
--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -10,8 +10,8 @@ use std::any::TypeId;
 use crate::{
     node_graph_system::NodeGraphSystem, BoxNodeFuture, ColorValue, Data, DataType, DataValue, Edge,
     EdgeId, ErrorTarget, ExecutionContext, GraphError, NodeEntity, NodeExecutionKind, NodeGraph,
-    NodeId, NodeImpl, NodeMeta, OutputWriter, SharedExecutionCache, SharedNodeStates, SubGraphNode,
-    Vector3,
+    NodeId, NodeImpl, NodeMeta, OutputWriter, SharedExecutionCache, SharedNodeStates, SlotDef,
+    SubGraphNode, Vector3,
 };
 
 /// Typed error returned by `NodeGraph::execute_sync` and `execute_async`.
@@ -431,22 +431,35 @@ impl NodeGraphWrite for NodeGraph {
         // Create node and get default data from factory
         let (node_id, default_data, type_id) = self.node_manager.create_node_by_name(name)?;
 
-        // Get type info for slot counts
-        let type_info = crate::get_node_type_info(name)
-            .ok_or_else(|| format!("NodeTypeInfo not found for '{}'", name))?;
+        // Static slot defs from inventory (when present); fall back to
+        // empty slots for runtime-registered factories. Runtime
+        // factories whose nodes are SubGraphNodes get their external
+        // proxy slots mirrored into NodeStates by
+        // `mirror_subgraph_external_slots` below.
+        let (resolved_name, inputs, outputs): (&'static str, &[SlotDef], &[SlotDef]) =
+            match crate::get_node_type_info(name) {
+                Some(info) => (info.name, info.inputs, info.outputs),
+                None => (self.node_manager.leaked_factory_name(name)?, &[], &[]),
+            };
 
         // Register in NodeStates
         {
             let mut guard = self.node_states.write().map_err(|e| e.to_string())?;
             guard.add_node(
                 node_id,
-                type_info.name,
+                resolved_name,
                 type_id,
                 default_data,
-                type_info.inputs,
-                type_info.outputs,
+                inputs,
+                outputs,
             );
         }
+
+        // Mirror SubGraph external slots into the parent NodeStates so
+        // recook / runtime-factory paths see the same slot count as
+        // the node's internal proxies expose. No-op for non-SubGraph
+        // nodes.
+        self.mirror_subgraph_external_slots(&node_id);
 
         Ok(node_id)
     }
@@ -455,20 +468,18 @@ impl NodeGraphWrite for NodeGraph {
         let (_node_id, default_data, type_id) =
             self.node_manager.create_node_by_name_with_id(id, name)?;
 
-        let type_info = crate::get_node_type_info(name)
-            .ok_or_else(|| format!("NodeTypeInfo not found for '{}'", name))?;
+        let (resolved_name, inputs, outputs): (&'static str, &[SlotDef], &[SlotDef]) =
+            match crate::get_node_type_info(name) {
+                Some(info) => (info.name, info.inputs, info.outputs),
+                None => (self.node_manager.leaked_factory_name(name)?, &[], &[]),
+            };
 
         {
             let mut guard = self.node_states.write().map_err(|e| e.to_string())?;
-            guard.add_node(
-                id,
-                type_info.name,
-                type_id,
-                default_data,
-                type_info.inputs,
-                type_info.outputs,
-            );
+            guard.add_node(id, resolved_name, type_id, default_data, inputs, outputs);
         }
+
+        self.mirror_subgraph_external_slots(&id);
 
         Ok(id)
     }
@@ -796,6 +807,114 @@ fn execute_node_sync(
 }
 
 impl NodeGraph {
+    // === Runtime factory passthroughs (pillar-2 BIM templates) ===========
+
+    /// Register a runtime-named factory on this graph's NodeManager so
+    /// nodes of that name can be created via `create_node_by_name` /
+    /// `create_node_by_name_with_id`. Mirrors
+    /// [`NodeManager::register_factory_with_name_owned`] so callers
+    /// that only have access to a `NodeGraph` (not the wrapped
+    /// `NodeManager`) can install per-instance factories.
+    pub fn register_factory_with_name_owned(
+        &mut self,
+        name: String,
+        factory: Arc<dyn Fn() -> Result<NodeEntity, String> + Send + Sync>,
+        default_data: Option<Data>,
+        type_id: Option<TypeId>,
+    ) {
+        self.node_manager
+            .register_factory_with_name_owned(name, factory, default_data, type_id);
+    }
+
+    /// Remove a runtime-named factory registration. Returns the
+    /// previous entry if any. Pass-through to
+    /// [`NodeManager::unregister_factory_by_name`].
+    pub fn unregister_factory_by_name(&mut self, name: &str) -> Option<crate::NodeFactoryWithMeta> {
+        self.node_manager.unregister_factory_by_name(name)
+    }
+
+    /// Re-insert a previously-removed factory registration under the
+    /// same (already-leaked) name. Pass-through to
+    /// [`NodeManager::restore_factory_registration`].
+    pub fn restore_factory_registration(
+        &mut self,
+        name: &str,
+        entry: crate::NodeFactoryWithMeta,
+    ) -> Result<(), crate::NodeFactoryWithMeta> {
+        self.node_manager.restore_factory_registration(name, entry)
+    }
+
+    /// Mirror a SubGraphNode's external proxy slots into the parent
+    /// `NodeStates`. No-op when the node is not a SubGraphNode.
+    ///
+    /// Reads:
+    ///   * the SubGraphNode's input proxy's OUTPUT slots → mirrored
+    ///     as the parent's external INPUT slots.
+    ///   * the SubGraphNode's output proxy's INPUT slots → mirrored
+    ///     as the parent's external OUTPUT slots.
+    ///
+    /// Idempotent: existing slots with the same (label, data_type)
+    /// are left intact; only the *count* extends. Used by
+    /// runtime-registered factories whose closures fully populate
+    /// the SubGraph internal proxies and need the parent NodeStates
+    /// to see the same external schema.
+    pub fn mirror_subgraph_external_slots(&self, node_id: &NodeId) {
+        let entity = match self.get_node_by_id(node_id) {
+            Some(e) => e,
+            None => return,
+        };
+        let read = match entity.read() {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+        let sg = match read.as_any().downcast_ref::<SubGraphNode>() {
+            Some(s) => s,
+            None => return,
+        };
+
+        // Read the SubGraphNode's internal proxy slot vocabularies.
+        let input_proxy_id = sg.input_proxy_id();
+        let output_proxy_id = sg.output_proxy_id();
+        let internal_ns = match sg.internal_graph().node_states.read() {
+            Ok(ns) => ns,
+            Err(_) => return,
+        };
+
+        let input_count = internal_ns.output_slot_count(&input_proxy_id);
+        let mut external_inputs: Vec<(&'static str, DataType)> = Vec::with_capacity(input_count);
+        for i in 0..input_count {
+            if let Some(slot) = internal_ns.output_slot(&input_proxy_id, i) {
+                external_inputs.push((slot.label, slot.data_type));
+            }
+        }
+        let output_count = internal_ns.input_slot_count(&output_proxy_id);
+        let mut external_outputs: Vec<(&'static str, DataType)> = Vec::with_capacity(output_count);
+        for i in 0..output_count {
+            if let Some(slot) = internal_ns.input_slot(&output_proxy_id, i) {
+                external_outputs.push((slot.label, slot.data_type));
+            }
+        }
+        drop(internal_ns);
+        drop(read);
+
+        let mut parent_ns = match self.node_states.write() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        let existing_inputs = parent_ns.input_slot_count(node_id);
+        for (i, (label, dt)) in external_inputs.into_iter().enumerate() {
+            if i >= existing_inputs {
+                parent_ns.add_input_slot(node_id, label, dt, None);
+            }
+        }
+        let existing_outputs = parent_ns.output_slot_count(node_id);
+        for (i, (label, dt)) in external_outputs.into_iter().enumerate() {
+            if i >= existing_outputs {
+                parent_ns.add_output_slot(node_id, label, dt);
+            }
+        }
+    }
+
     // === Public synchronous API ===========================================
 
     /// Execute the dirty graph synchronously with the default scheduling

--- a/src/node_graph/node_manager.rs
+++ b/src/node_graph/node_manager.rs
@@ -273,6 +273,30 @@ impl NodeManager {
         self.name_registry.get(name)
     }
 
+    /// Return the leaked-`&'static str` form of a runtime-registered
+    /// factory name. Used by `NodeGraph::create_node_by_name(_with_id)`
+    /// to obtain a `'static` name pointer for `NodeStates::add_node`
+    /// when the inventory `NodeTypeInfo` lookup misses.
+    ///
+    /// Returns `Err` when the name has never been registered via
+    /// `register_factory_with_name(_owned)` — the caller should
+    /// surface this as the same "NodeTypeInfo not found" error it
+    /// would emit for a missing inventory entry.
+    pub fn leaked_factory_name(&self, name: &str) -> Result<&'static str, String> {
+        // First try the name_registry (covers `register_factory_with_name`
+        // entries which receive `&'static str` keys directly).
+        if let Some((k, _)) = self.name_registry.get_key_value(name) {
+            return Ok(*k);
+        }
+        // Fall back to the leaked-name table for owned-name registrations
+        // whose `name_registry` entry might have been temporarily removed
+        // by `unregister_factory_by_name`.
+        self.leaked_names
+            .get(name)
+            .copied()
+            .ok_or_else(|| format!("NodeTypeInfo not found for '{}'", name))
+    }
+
     /// Create a node by type (compile-time dispatch).
     pub fn create_node<T: NodeImpl + 'static>(&mut self) -> Result<NodeId, String> {
         if let Some(factory) = self.node_registry.get(&TypeId::of::<T>()) {

--- a/src/node_graph/node_manager.rs
+++ b/src/node_graph/node_manager.rs
@@ -58,6 +58,11 @@ pub struct NodeManager {
     /// Name-based registry for dynamic node creation.
     name_registry: HashMap<&'static str, NodeFactoryWithMeta>,
     variants: HashSet<String>,
+    /// Names that were leaked into `&'static str` for runtime
+    /// registration. Tracked so that
+    /// [`restore_factory_registration`] can find a previously-leaked
+    /// key after the corresponding `name_registry` entry was removed.
+    leaked_names: HashMap<String, &'static str>,
 }
 
 pub type NodeRegistrationFn = fn(&mut NodeManager) -> Result<(), String>;
@@ -188,6 +193,86 @@ impl NodeManager {
         );
     }
 
+    /// Register a factory with a runtime-built (owned) name. The name
+    /// is leaked once into a `&'static str` so it can be inserted into
+    /// the same `name_registry` keyed by `&'static str`.
+    ///
+    /// Intended for callers that build factory names from user-supplied
+    /// data at runtime (e.g. per-variant SubGraph factories in the
+    /// modeling example's pillar 2). Re-registering an existing name
+    /// replaces the entry without leaking again.
+    pub fn register_factory_with_name_owned(
+        &mut self,
+        name: String,
+        factory: NodeFactory,
+        default_data: Option<Data>,
+        type_id: Option<TypeId>,
+    ) {
+        // Reuse a previously-leaked key for the same name so that the
+        // leaked-string footprint is bounded by the count of distinct
+        // factory names ever registered (re-registration / unregister +
+        // re-register cycles do not leak again).
+        let key: &'static str = match self.leaked_names.get(&name) {
+            Some(existing) => *existing,
+            None => {
+                let leaked: &'static str = Box::leak(name.clone().into_boxed_str());
+                self.leaked_names.insert(name, leaked);
+                leaked
+            }
+        };
+        self.name_registry.insert(
+            key,
+            NodeFactoryWithMeta {
+                factory,
+                default_data,
+                type_id,
+            },
+        );
+    }
+
+    /// Remove a name-based factory registration. Returns the removed
+    /// entry if one was present. Used by callers that need to roll back
+    /// a registration after a downstream commit failure.
+    pub fn unregister_factory_by_name(&mut self, name: &str) -> Option<NodeFactoryWithMeta> {
+        self.name_registry.remove(name)
+    }
+
+    /// Re-insert a previously-removed registration entry under the same
+    /// (already-leaked) name. The companion to
+    /// [`unregister_factory_by_name`] for atomic rollback paths.
+    ///
+    /// If the name is unknown (never been leaked / registered), the
+    /// entry is dropped — callers must therefore only restore entries
+    /// for names that were obtained via a prior `take` on the same
+    /// manager.
+    pub fn restore_factory_registration(
+        &mut self,
+        name: &str,
+        entry: NodeFactoryWithMeta,
+    ) -> Result<(), NodeFactoryWithMeta> {
+        // Look up either the live key (still in name_registry) or the
+        // leaked-name table (key was removed by a prior unregister).
+        let key: Option<&'static str> = self
+            .name_registry
+            .get_key_value(name)
+            .map(|(k, _)| *k)
+            .or_else(|| self.leaked_names.get(name).copied());
+        match key {
+            Some(k) => {
+                self.name_registry.insert(k, entry);
+                Ok(())
+            }
+            None => Err(entry),
+        }
+    }
+
+    /// Read-only lookup for a name-based factory registration. Used by
+    /// rollback paths that need to capture the previous entry's
+    /// metadata before overwriting.
+    pub fn factory_meta_by_name(&self, name: &str) -> Option<&NodeFactoryWithMeta> {
+        self.name_registry.get(name)
+    }
+
     /// Create a node by type (compile-time dispatch).
     pub fn create_node<T: NodeImpl + 'static>(&mut self) -> Result<NodeId, String> {
         if let Some(factory) = self.node_registry.get(&TypeId::of::<T>()) {
@@ -267,8 +352,125 @@ impl NodeManager {
         self.name_registry.contains_key(name)
     }
 
+    /// Convenience alias for [`is_registered`]. Reads more naturally at
+    /// call sites that ask "does this factory exist" rather than "is
+    /// this name registered".
+    pub fn has_factory(&self, name: &str) -> bool {
+        self.is_registered(name)
+    }
+
+    /// Identity probe for a name-based factory registration. Returns
+    /// the address of the underlying factory closure (`Arc::as_ptr`)
+    /// when registered. Two factories registered under different names
+    /// will compare unequal; re-registering a name with a fresh closure
+    /// changes the returned pointer.
+    ///
+    /// Pillar-2 of the modeling example uses this to assert that two
+    /// variants registered under different names hold independent
+    /// closures (per `factory_id != factory_id`).
+    pub fn factory_id(&self, name: &str) -> Option<*const ()> {
+        self.name_registry
+            .get(name)
+            .map(|meta| Arc::as_ptr(&meta.factory) as *const ())
+    }
+
     /// Get all registered node type names.
     pub fn registered_names(&self) -> Vec<&'static str> {
         self.name_registry.keys().copied().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NodeCore, NodeImpl};
+
+    /// Trivial node for register/unregister tests.
+    #[derive(Debug)]
+    struct Probe;
+    impl NodeImpl for Probe {
+        fn execute_sync(&self, _ctx: crate::ExecutionContext) -> Result<(), String> {
+            Ok(())
+        }
+    }
+    impl NodeCore for Probe {
+        fn node_name(&self) -> &'static str {
+            "Probe"
+        }
+        fn register_in(_manager: &mut NodeManager) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    fn probe_factory() -> NodeFactory {
+        Arc::new(|| Ok(Arc::new(RwLock::new(Probe)) as NodeEntity))
+    }
+
+    #[test]
+    fn register_factory_with_name_owned_inserts_runtime_name() {
+        let mut nm = NodeManager::default();
+        nm.register_factory_with_name_owned(
+            "VariantFactory_x_runtime".to_string(),
+            probe_factory(),
+            None,
+            None,
+        );
+        assert!(nm.has_factory("VariantFactory_x_runtime"));
+        assert!(nm.factory_id("VariantFactory_x_runtime").is_some());
+    }
+
+    #[test]
+    fn register_factory_with_name_owned_does_not_releak_on_replace() {
+        let mut nm = NodeManager::default();
+        nm.register_factory_with_name_owned("Foo".to_string(), probe_factory(), None, None);
+        let names_after_first = nm.registered_names().len();
+        nm.register_factory_with_name_owned("Foo".to_string(), probe_factory(), None, None);
+        // Replacement: same key reused, no extra entry.
+        assert_eq!(nm.registered_names().len(), names_after_first);
+    }
+
+    #[test]
+    fn unregister_factory_by_name_returns_entry_and_removes() {
+        let mut nm = NodeManager::default();
+        nm.register_factory_with_name_owned("Bar".to_string(), probe_factory(), None, None);
+        let removed = nm.unregister_factory_by_name("Bar");
+        assert!(removed.is_some());
+        assert!(!nm.has_factory("Bar"));
+    }
+
+    #[test]
+    fn restore_factory_registration_only_succeeds_for_known_name() {
+        let mut nm = NodeManager::default();
+        nm.register_factory_with_name_owned("Baz".to_string(), probe_factory(), None, None);
+        let entry = nm.unregister_factory_by_name("Baz").expect("removed entry");
+        // The leaked-key set still contains "Baz" (we keyed on the same
+        // string), so restore must succeed even after the name_registry
+        // entry was removed.
+        assert!(nm.restore_factory_registration("Baz", entry).is_ok());
+        assert!(nm.has_factory("Baz"));
+    }
+
+    #[test]
+    fn restore_factory_registration_rejects_unknown_name() {
+        let mut nm = NodeManager::default();
+        let entry = NodeFactoryWithMeta {
+            factory: probe_factory(),
+            default_data: None,
+            type_id: None,
+        };
+        let err = nm
+            .restore_factory_registration("never_registered", entry)
+            .err();
+        assert!(err.is_some(), "restore must reject unknown name");
+    }
+
+    #[test]
+    fn factory_id_distinguishes_separate_registrations() {
+        let mut nm = NodeManager::default();
+        nm.register_factory_with_name_owned("A".to_string(), probe_factory(), None, None);
+        nm.register_factory_with_name_owned("B".to_string(), probe_factory(), None, None);
+        let a = nm.factory_id("A").unwrap();
+        let b = nm.factory_id("B").unwrap();
+        assert_ne!(a, b);
     }
 }


### PR DESCRIPTION
## Summary

Adds runtime-named factory APIs to `NodeManager` plus a bridge through `NodeGraph` so consumers can register, replace, and atomically restore SubGraph factories under arbitrary `String` keys at runtime — the cornerstone of revion's pillar-2 BIM template flow (user-authored Wall variants become uniquely-named cognet factories at "Done" click).

## What's new

**Commit `6a93c18` — `NodeManager` runtime factory bridge:**

- `register_factory_with_name_owned(String, NodeFactoryWithMeta) -> Option<NodeFactoryWithMeta>` — register under a runtime-owned key, return the previous registration entry if any (for caller-side rollback).
- `unregister_factory_by_name(&str) -> Option<NodeFactoryWithMeta>` — remove and return the registration entry.
- `restore_factory_registration(&str, NodeFactoryWithMeta)` — re-install a previously captured entry (re-uses previously-leaked `&'static str` keys via an internal `leaked_names: HashMap<String, &'static str>` table so repeated register/restore cycles do not leak per cycle).
- `has_factory(&str) -> bool`, `factory_id(&str) -> Option<*const ()>`, `factory_meta_by_name(&str) -> Option<&NodeFactoryWithMeta>` — read-side helpers used by tests and callers verifying rollback state.
- `leaked_factory_name(&str) -> Option<&'static str>` — accessor for runtime-registered names.

6 unit tests cover: register, unregister, restore, replace-without-leak, unknown-name rejection, factory_id distinctness across runtime registrations.

**Commit `4db0304` — `NodeGraph` runtime-factory bridge + SubGraph slot mirror:**

- `NodeGraph::register_factory_with_name_owned` / `unregister_factory_by_name` / `restore_factory_registration` — pass-through wrappers so consumers holding only a `NodeGraph` handle can install runtime factories.
- `NodeGraph::mirror_subgraph_external_slots(SubGraphNode) -> NodeStates` — auto-mirrors a SubGraphNode's internal proxy slot schema into the parent NodeStates (count-monotonic; documented as such).
- `create_node_by_name(_with_id)` — falls back to runtime-registry name + empty `SlotDef` list when no inventory `NodeTypeInfo` is registered for the runtime name, then auto-mirrors the SubGraph external slots.

## Why

Revion pillar 2 ships user-authored BIM object templates. Each authored variant becomes its own cognet factory under a sanitised runtime name (`WallVariant_x_<sanitised>`), registered when the user clicks "Done" in authoring mode. Three properties drive the API choice:

1. **Atomicity** — exit_authoring is atomic on the revion side: clash check, register, recook commit, registry insert. If any step fails the registration must roll back to the prior state. The `register…_owned` → previous, plus `restore_factory_registration` is the matched pair that makes this clean.
2. **Per-variant identity** — design (j) in the pillar-2 plan rules out a single TypeId for all "Wall variants"; each gets its own factory under its own runtime name so MyWall_v1 recook can't accidentally target MyWall_v2 instances.
3. **No app-side workarounds** — per revion's `.claude/rules/no-workarounds.md`, framework gaps get fixed in the framework. The auto-slot-mirroring is the corollary: a Pillar-2 caller building a SubGraph by replaying structural changes shouldn't have to re-publish the proxy schema to the parent NodeStates manually.

## Test plan

- [x] `cargo nextest run -p cognet` — 48 tests pass (42 pre-existing + 6 new on `NodeManager`).
- [x] revion's pillar-2 branch consumes these APIs end-to-end (`exit_authoring` atomic-rollback paths, `register_variant_factory_on_both_managers` in revion).