### PR TITLE
docs(color): Pin ColorValue canonical range to 0.0..=1.0

### DIFF
--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -37,6 +37,13 @@ impl Vector3 {
 }
 
 /// An RGBA color value for passing color data through the graph.
+///
+/// Channels are normalized to the **0.0..=1.0 range** (graphics
+/// convention, matching WGPU / OpenGL / sRGB-float). Producers must
+/// emit values in this range; consumers that need 8-bit channels
+/// should multiply by `255.0` at the boundary. The range is not
+/// runtime-enforced — keeping the contract is the producer's
+/// responsibility.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ColorValue {
     pub r: f64,
@@ -46,6 +53,10 @@ pub struct ColorValue {
 }
 
 impl ColorValue {
+    /// Construct a `ColorValue`. `r`, `g`, `b`, `a` are expected to be
+    /// in the 0.0..=1.0 range (see struct docs). Out-of-range values
+    /// are passed through without clamping so callers that intentionally
+    /// over- or under-saturate (e.g. HDR producers) still work.
     pub fn new(r: f64, g: f64, b: f64, a: f64) -> Self {
         Self { r, g, b, a }
     }

--- a/src/node/primitives/color.rs
+++ b/src/node/primitives/color.rs
@@ -21,11 +21,14 @@ impl NodeMeta for ColorNode {
         data_type: DataType::Color,
         max_connections: None,
     }];
+    // `ColorValue` channels are canonically 0.0..=1.0 — see the doc on
+    // `ColorValue` in `edge/slot.rs`. White = fully-opaque
+    // `(1.0, 1.0, 1.0, 1.0)`.
     const DEFAULT_VALUE: DefaultValue = DefaultValue::Color {
-        r: 255.0,
-        g: 255.0,
-        b: 255.0,
-        a: 255.0,
+        r: 1.0,
+        g: 1.0,
+        b: 1.0,
+        a: 1.0,
     };
 }
 


### PR DESCRIPTION
## Summary
- Producers were inconsistent on `ColorValue` channel range — `Color` primitive's `DEFAULT_VALUE` used 0..=255 while downstream consumers expected 0..=1
- Pin the contract to **0.0..=1.0** (graphics standard, matches WGPU / sRGB-float)
- Update `Color` primitive's default to `(1.0, 1.0, 1.0, 1.0)` and document the producer obligation on the struct

## Test plan
- [x] `cargo nextest run` — 98/98 pass
- [x] Downstream revion build green against this branch