### PR TITLE
feat(node): Add inspector_visible flag to SlotDef

### DIFF
--- a/src/node/operators/add.rs
+++ b/src/node/operators/add.rs
@@ -14,17 +14,20 @@ impl NodeMeta for AddNode {
             label: "A",
             data_type: DataType::Number,
             max_connections: Some(1),
+            inspector_visible: true,
         },
         SlotDef {
             label: "B",
             data_type: DataType::Number,
             max_connections: Some(1),
+            inspector_visible: true,
         },
     ];
     const OUTPUTS: &'static [SlotDef] = &[SlotDef {
         label: "Sum",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
 }
 

--- a/src/node/operators/add_list.rs
+++ b/src/node/operators/add_list.rs
@@ -13,11 +13,13 @@ impl NodeMeta for AddListNode {
         label: "Numbers",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
     const OUTPUTS: &'static [SlotDef] = &[SlotDef {
         label: "Sum",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
 }
 

--- a/src/node/operators/divide.rs
+++ b/src/node/operators/divide.rs
@@ -18,17 +18,20 @@ impl NodeMeta for DivideNode {
             label: "A",
             data_type: DataType::Number,
             max_connections: Some(1),
+            inspector_visible: true,
         },
         SlotDef {
             label: "B",
             data_type: DataType::Number,
             max_connections: Some(1),
+            inspector_visible: true,
         },
     ];
     const OUTPUTS: &'static [SlotDef] = &[SlotDef {
         label: "Quotient",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
 }
 

--- a/src/node/operators/divide_list.rs
+++ b/src/node/operators/divide_list.rs
@@ -18,11 +18,13 @@ impl NodeMeta for DivideListNode {
         label: "Numbers",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
     const OUTPUTS: &'static [SlotDef] = &[SlotDef {
         label: "Quotient",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
 }
 

--- a/src/node/operators/multiply.rs
+++ b/src/node/operators/multiply.rs
@@ -13,17 +13,20 @@ impl NodeMeta for MultiplyNode {
             label: "A",
             data_type: DataType::Number,
             max_connections: Some(1),
+            inspector_visible: true,
         },
         SlotDef {
             label: "B",
             data_type: DataType::Number,
             max_connections: Some(1),
+            inspector_visible: true,
         },
     ];
     const OUTPUTS: &'static [SlotDef] = &[SlotDef {
         label: "Product",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
 }
 

--- a/src/node/operators/multiply_list.rs
+++ b/src/node/operators/multiply_list.rs
@@ -13,11 +13,13 @@ impl NodeMeta for MultiplyListNode {
         label: "Numbers",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
     const OUTPUTS: &'static [SlotDef] = &[SlotDef {
         label: "Product",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
 }
 

--- a/src/node/operators/subtract.rs
+++ b/src/node/operators/subtract.rs
@@ -13,17 +13,20 @@ impl NodeMeta for SubtractNode {
             label: "A",
             data_type: DataType::Number,
             max_connections: Some(1),
+            inspector_visible: true,
         },
         SlotDef {
             label: "B",
             data_type: DataType::Number,
             max_connections: Some(1),
+            inspector_visible: true,
         },
     ];
     const OUTPUTS: &'static [SlotDef] = &[SlotDef {
         label: "Difference",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
 }
 

--- a/src/node/operators/subtract_list.rs
+++ b/src/node/operators/subtract_list.rs
@@ -13,11 +13,13 @@ impl NodeMeta for SubtractListNode {
         label: "Numbers",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
     const OUTPUTS: &'static [SlotDef] = &[SlotDef {
         label: "Difference",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
 }
 

--- a/src/node/outputs/number_output.rs
+++ b/src/node/outputs/number_output.rs
@@ -12,6 +12,7 @@ impl NodeMeta for NumberOutput {
         label: "Value",
         data_type: DataType::Number,
         max_connections: Some(1),
+        inspector_visible: true,
     }];
     const OUTPUTS: &'static [SlotDef] = &[];
 }

--- a/src/node/outputs/string_output.rs
+++ b/src/node/outputs/string_output.rs
@@ -12,6 +12,7 @@ impl NodeMeta for StringOutput {
         label: "Value",
         data_type: DataType::String,
         max_connections: Some(1),
+        inspector_visible: true,
     }];
     const OUTPUTS: &'static [SlotDef] = &[];
 }

--- a/src/node/primitives/color.rs
+++ b/src/node/primitives/color.rs
@@ -20,6 +20,7 @@ impl NodeMeta for ColorNode {
         label: "Value",
         data_type: DataType::Color,
         max_connections: None,
+        inspector_visible: true,
     }];
     const DEFAULT_VALUE: DefaultValue = DefaultValue::Color {
         r: 255.0,

--- a/src/node/primitives/number.rs
+++ b/src/node/primitives/number.rs
@@ -14,6 +14,7 @@ impl NodeMeta for NumberNode {
         label: "Value",
         data_type: DataType::Number,
         max_connections: None,
+        inspector_visible: true,
     }];
     const DEFAULT_VALUE: DefaultValue = DefaultValue::Number(10.0);
 }

--- a/src/node/primitives/string.rs
+++ b/src/node/primitives/string.rs
@@ -14,6 +14,7 @@ impl NodeMeta for StringNode {
         label: "Value",
         data_type: DataType::String,
         max_connections: None,
+        inspector_visible: true,
     }];
     const DEFAULT_VALUE: DefaultValue = DefaultValue::String("Hello");
 }

--- a/src/node/primitives/vector3.rs
+++ b/src/node/primitives/vector3.rs
@@ -20,6 +20,7 @@ impl NodeMeta for Vector3Node {
         label: "Value",
         data_type: DataType::Vector3,
         max_connections: None,
+        inspector_visible: true,
     }];
     const DEFAULT_VALUE: DefaultValue = DefaultValue::Vector3 {
         x: 0.0,

--- a/src/node/primitives/vertex.rs
+++ b/src/node/primitives/vertex.rs
@@ -21,6 +21,7 @@ impl NodeMeta for VertexNode {
         label: "Value",
         data_type: DataType::Vector3,
         max_connections: None,
+        inspector_visible: true,
     }];
     const DEFAULT_VALUE: DefaultValue = DefaultValue::Vector3 {
         x: 0.0,

--- a/src/node/subgraph/mod.rs
+++ b/src/node/subgraph/mod.rs
@@ -109,10 +109,17 @@ impl SubGraphNode {
         label: &'static str,
         data_type: DataType,
         max_connections: Option<usize>,
+        inspector_visible: bool,
     ) -> Result<(), String> {
         let in_path = sg_path.child(self.input_proxy_id);
         let mut ns = graph.node_states().write().map_err(|e| e.to_string())?;
-        ns.add_input_slot(&in_path, label, data_type, max_connections);
+        ns.add_input_slot(
+            &in_path,
+            label,
+            data_type,
+            max_connections,
+            inspector_visible,
+        );
         ns.add_output_slot(&in_path, label, data_type);
         Ok(())
     }

--- a/src/node/type_info.rs
+++ b/src/node/type_info.rs
@@ -93,11 +93,40 @@ impl DefaultValue {
 }
 
 /// Static definition of a slot (input or output port).
+///
+/// `inspector_visible` controls whether downstream property inspectors should
+/// render an editor for this slot. Set `false` for structural / aggregate
+/// ports whose value comes from graph topology rather than user typing
+/// (e.g. multi-input collectors, hierarchical membership ports). Default
+/// `true` (set via [`SlotDef::new`]).
 #[derive(Debug, Clone, Copy)]
 pub struct SlotDef {
     pub label: &'static str,
     pub data_type: DataType,
     pub max_connections: Option<usize>,
+    pub inspector_visible: bool,
+}
+
+impl SlotDef {
+    /// Build a slot definition with `inspector_visible: true` (default).
+    pub const fn new(
+        label: &'static str,
+        data_type: DataType,
+        max_connections: Option<usize>,
+    ) -> Self {
+        Self {
+            label,
+            data_type,
+            max_connections,
+            inspector_visible: true,
+        }
+    }
+
+    /// Set `inspector_visible` (chainable in const contexts).
+    pub const fn with_inspector_visible(mut self, visible: bool) -> Self {
+        self.inspector_visible = visible;
+        self
+    }
 }
 
 /// Trait for nodes to provide static metadata.

--- a/src/node_graph/interface_helpers.rs
+++ b/src/node_graph/interface_helpers.rs
@@ -71,7 +71,7 @@ impl NodeGraph {
         let index = {
             let mut ns = self.node_states.write().map_err(|e| e.to_string())?;
             let node_path = NodePath::root().child(*node_id);
-            let in_idx = ns.add_input_slot(&node_path, label, data_type, Some(1));
+            let in_idx = ns.add_input_slot(&node_path, label, data_type, Some(1), true);
             let out_idx = ns.add_output_slot(&node_path, label, data_type);
             // Invariant: input and output slot indices stay in lock-step.
             assert_eq!(

--- a/src/node_graph/mod.rs
+++ b/src/node_graph/mod.rs
@@ -241,6 +241,13 @@ impl NodeGraph {
         self.input_slot_data_type_at(&NodePath::root().child(*node_id), slot)
     }
 
+    /// Whether an input slot should be rendered as an editable row by
+    /// downstream property inspectors. Path-aware sibling lives at
+    /// [`NodeGraph::input_slot_inspector_visible_at`].
+    pub fn input_slot_inspector_visible(&self, node_id: &NodeId, slot: usize) -> Option<bool> {
+        self.input_slot_inspector_visible_at(&NodePath::root().child(*node_id), slot)
+    }
+
     /// Get the default value of an input slot.
     pub fn input_slot_default_value(&self, node_id: &NodeId, slot: usize) -> Option<DataValue> {
         let ns = self.node_states.read().ok()?;

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -1512,6 +1512,7 @@ mod sync_executor_tests {
             label: "Out",
             data_type: crate::DataType::Number,
             max_connections: None,
+            inspector_visible: true,
         }];
         const DEFAULT_VALUE: crate::DefaultValue = crate::DefaultValue::Number(42.0);
     }
@@ -1669,6 +1670,7 @@ mod sync_executor_tests {
                 label: "Out",
                 data_type: crate::DataType::Number,
                 max_connections: None,
+                inspector_visible: true,
             }];
             const DEFAULT_VALUE: crate::DefaultValue = crate::DefaultValue::Number(0.0);
         }
@@ -1720,6 +1722,7 @@ mod sync_executor_tests {
             label: "Out",
             data_type: crate::DataType::Number,
             max_connections: None,
+            inspector_visible: true,
         }];
         const DEFAULT_VALUE: crate::DefaultValue = crate::DefaultValue::Number(0.0);
     }
@@ -1826,6 +1829,7 @@ mod sync_executor_tests {
             label: "Out",
             data_type: crate::DataType::Number,
             max_connections: None,
+            inspector_visible: true,
         }];
         const DEFAULT_VALUE: crate::DefaultValue = crate::DefaultValue::Number(0.0);
     }

--- a/src/node_graph/node_graph_system.rs
+++ b/src/node_graph/node_graph_system.rs
@@ -402,11 +402,13 @@ mod subgraph_edge_alias_tests {
             label: "x",
             data_type: crate::DataType::Number,
             max_connections: Some(1),
+            inspector_visible: true,
         }];
         const OUTPUTS: &'static [crate::SlotDef] = &[crate::SlotDef {
             label: "x",
             data_type: crate::DataType::Number,
             max_connections: None,
+            inspector_visible: true,
         }];
         const DEFAULT_VALUE: crate::DefaultValue = crate::DefaultValue::None;
     }

--- a/src/node_graph/node_state.rs
+++ b/src/node_graph/node_state.rs
@@ -35,13 +35,27 @@ impl NodeState {
 }
 
 /// Runtime state for input slots.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct InputSlotState {
     pub id: InputSlotId,
     pub label: &'static str,
     pub data_type: DataType,
     pub max_connections: Option<usize>,
+    pub inspector_visible: bool,
     pub default_value: Option<DataValue>,
+}
+
+impl Default for InputSlotState {
+    fn default() -> Self {
+        Self {
+            id: InputSlotId::default(),
+            label: "",
+            data_type: DataType::default(),
+            max_connections: None,
+            inspector_visible: true,
+            default_value: None,
+        }
+    }
 }
 
 /// Runtime state for output slots.
@@ -116,6 +130,7 @@ impl NodeStates {
                 label: def.label,
                 data_type: def.data_type,
                 max_connections: def.max_connections,
+                inspector_visible: def.inspector_visible,
                 default_value: None,
             };
             self.input_slot_owner.insert(slot.id, (path.clone(), i));
@@ -144,6 +159,7 @@ impl NodeStates {
         label: &'static str,
         data_type: DataType,
         max_connections: Option<usize>,
+        inspector_visible: bool,
     ) -> usize {
         let index = self.input_slot_count(path);
         let slot = InputSlotState {
@@ -151,6 +167,7 @@ impl NodeStates {
             label,
             data_type,
             max_connections,
+            inspector_visible,
             default_value: None,
         };
         self.input_slot_owner.insert(slot.id, (path.clone(), index));
@@ -175,6 +192,22 @@ impl NodeStates {
             .insert(slot.id, (path.clone(), index));
         self.output_slots.insert((path.clone(), index), slot);
         index
+    }
+
+    /// Rewrite the `inspector_visible` flag of an input slot. Returns
+    /// `true` on success, `false` if the slot does not exist.
+    pub fn set_input_slot_inspector_visible(
+        &mut self,
+        path: &NodePath,
+        index: usize,
+        visible: bool,
+    ) -> bool {
+        if let Some(slot) = self.input_slots.get_mut(&(path.clone(), index)) {
+            slot.inspector_visible = visible;
+            true
+        } else {
+            false
+        }
     }
 
     /// Rewrite the label of an input slot in place. Slot index and id
@@ -632,7 +665,7 @@ mod tests {
 
         ns.add_node(&sg_path, "SubGraph", None, None, &[], &[]);
         ns.add_node(&in_path, "Interface", None, None, &[], &[]);
-        ns.add_input_slot(&in_path, "value", DataType::Number, Some(1));
+        ns.add_input_slot(&in_path, "value", DataType::Number, Some(1), true);
 
         let schema = ns.subgraph_external_inputs(&sg_path, in_id);
         assert_eq!(schema.len(), 1);
@@ -652,7 +685,7 @@ mod tests {
 
         ns.add_node(&sg_path, "SubGraph", None, None, &[], &[]);
         ns.add_node(&out_path, "Interface", None, None, &[], &[]);
-        ns.add_input_slot(&out_path, "result", DataType::Number, None);
+        ns.add_input_slot(&out_path, "result", DataType::Number, None, true);
 
         let schema = ns.subgraph_external_outputs(&sg_path, out_id);
         assert_eq!(schema.len(), 1);
@@ -670,7 +703,7 @@ mod tests {
         ns.add_node(&path, "Test", None, None, &[], &[]);
 
         // Add one input slot and one output slot dynamically.
-        let in_idx = ns.add_input_slot(&path, "in", DataType::Number, Some(1));
+        let in_idx = ns.add_input_slot(&path, "in", DataType::Number, Some(1), true);
         let out_idx = ns.add_output_slot(&path, "out", DataType::Number);
 
         let in_sid = ns.input_slot(&path, in_idx).unwrap().id;
@@ -706,11 +739,13 @@ mod tests {
             label: "value",
             data_type: DataType::Number,
             max_connections: Some(1),
+            inspector_visible: true,
         }];
         let output_defs = [SlotDef {
             label: "result",
             data_type: DataType::Number,
             max_connections: None,
+            inspector_visible: true,
         }];
 
         ns.add_node(&path, "Test", None, None, &input_defs, &output_defs);
@@ -739,7 +774,7 @@ mod tests {
         let path = NodePath::root().child(node_id);
 
         ns.add_node(&path, "Test", None, None, &[], &[]);
-        ns.add_input_slot(&path, "i", DataType::Number, None);
+        ns.add_input_slot(&path, "i", DataType::Number, None, true);
         ns.add_output_slot(&path, "o", DataType::Number);
 
         let in_sid = ns.input_slot(&path, 0).unwrap().id;

--- a/src/node_graph/path_api.rs
+++ b/src/node_graph/path_api.rs
@@ -184,6 +184,30 @@ impl NodeGraph {
         ns.input_slot(path, slot).map(|s| s.data_type)
     }
 
+    /// Whether an input slot should be rendered as an editable row by
+    /// downstream property inspectors. Returns `None` when the slot does
+    /// not exist; callers may treat that as visible.
+    pub fn input_slot_inspector_visible_at(&self, path: &NodePath, slot: usize) -> Option<bool> {
+        let ns = self.node_states.read().ok()?;
+        ns.input_slot(path, slot).map(|s| s.inspector_visible)
+    }
+
+    /// Override the `inspector_visible` flag of an existing input slot.
+    /// Returns `true` on success, `false` if the slot does not exist.
+    /// Used by callers that create dynamic SubGraph ports and want to
+    /// mark a subset of them as structural (hidden from Inspectors).
+    pub fn set_input_slot_inspector_visible_at(
+        &self,
+        path: &NodePath,
+        slot: usize,
+        visible: bool,
+    ) -> bool {
+        let Ok(mut ns) = self.node_states.write() else {
+            return false;
+        };
+        ns.set_input_slot_inspector_visible(path, slot, visible)
+    }
+
     // ── SubGraph external slot helpers (plan-006 C17 Step 11.5c) ──
 
     /// Return the `(NodePath, InputSlotId)` pair that an external edge targets
@@ -904,6 +928,7 @@ mod tests {
             label: "In",
             data_type: crate::DataType::Vector3,
             max_connections: Some(1),
+            inspector_visible: true,
         }];
         const OUTPUTS: &'static [crate::SlotDef] = &[];
     }

--- a/src/node_graph/subgraph_helpers.rs
+++ b/src/node_graph/subgraph_helpers.rs
@@ -140,10 +140,16 @@ impl NodeGraph {
         let sg_path = NodePath::root().child(*node_id);
         let in_path = sg_path.child(input_proxy_id);
         let mut ns = self.node_states.write().map_err(|e| e.to_string())?;
-        ns.add_input_slot(&in_path, label, data_type, Some(1));
+        ns.add_input_slot(&in_path, label, data_type, Some(1), true);
         ns.add_output_slot(&in_path, label, data_type);
         // Sync external slot on parent SubGraphNode.
-        ns.add_input_slot(&NodePath::root().child(*node_id), label, data_type, None);
+        ns.add_input_slot(
+            &NodePath::root().child(*node_id),
+            label,
+            data_type,
+            None,
+            true,
+        );
         Ok(())
     }
 
@@ -213,7 +219,7 @@ impl NodeGraph {
         let sg_path = NodePath::root().child(*node_id);
         let out_path = sg_path.child(output_proxy_id);
         let mut ns = self.node_states.write().map_err(|e| e.to_string())?;
-        ns.add_input_slot(&out_path, label, data_type, None);
+        ns.add_input_slot(&out_path, label, data_type, None, true);
         ns.add_output_slot(&out_path, label, data_type);
         // Sync external slot on parent SubGraphNode.
         ns.add_output_slot(&NodePath::root().child(*node_id), label, data_type);


### PR DESCRIPTION
## Summary
- Add `inspector_visible: bool` field to `SlotDef` (default `true`) so node authors can mark structural / aggregate input ports (multi-input collectors, hierarchical membership ports) as hidden from downstream property inspectors
- Mirror the flag onto `InputSlotState` and propagate it through `add_input_slot` / `add_node` so dynamic SubGraph slot creation honours the same setting
- New query: `NodeGraph::input_slot_inspector_visible{,_at}` returns `Option<bool>` (`None` when the slot does not exist; callers may treat that as visible)
- New mutator: `set_input_slot_inspector_visible_at(path, slot, visible) -> bool` lets downstream callers override the flag on dynamically-created SubGraph external slots after creation

Default `true` preserves all existing behaviour; revion's modeling example sets `false` on a handful of structural ports (BuildingLayer.Floors, CostAggregator.children, OpeningAggregator.placements, Wall variant external openings / Floor).

## Independent of #74
Touches `src/node/type_info.rs` (SlotDef definition) and `node_graph/` query plumbing; PR #74 only touches `src/edge/slot.rs` + `src/node/primitives/color.rs`. The two PRs do not overlap and can land in either order.

## Test plan
- [x] `cargo nextest run` — 98/98 pass
- [x] Downstream revion uses the new flag end-to-end (sidebar Wall selection + property Inspector verified)