### PR TITLE
fix(executor): Preserve Domain/Mesh defaults through interface fallback

### DIFF
--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -207,10 +207,9 @@ fn build_execution_context(
                 // non-primitive type.
                 if values.is_empty() {
                     if let Some(default_ref) = slot_state.default_value.as_ref() {
-                        if let Ok(data) = Data::from_any_typed(
-                            Arc::clone(default_ref),
-                            slot_state.data_type,
-                        ) {
+                        if let Ok(data) =
+                            Data::from_any_typed(Arc::clone(default_ref), slot_state.data_type)
+                        {
                             values.push(data);
                         }
                     }

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -199,10 +199,18 @@ fn build_execution_context(
                         }
                     }
                 }
-                // Default value fallback when no edges are connected
+                // Default value fallback when no edges are connected.
+                // `from_any_typed` carries the slot's declared `data_type`
+                // through type erasure so `Domain<_>` / `Mesh` / `BRep`
+                // defaults round-trip correctly. `from_any` would lose the
+                // domain tag and silently drop the default for every
+                // non-primitive type.
                 if values.is_empty() {
                     if let Some(default_ref) = slot_state.default_value.as_ref() {
-                        if let Ok(data) = Data::from_any(Arc::clone(default_ref)) {
+                        if let Ok(data) = Data::from_any_typed(
+                            Arc::clone(default_ref),
+                            slot_state.data_type,
+                        ) {
                             values.push(data);
                         }
                     }
@@ -285,8 +293,15 @@ fn resolve_value_through_interface(
     }
     // Fallback: the InterfaceNode's input slot default (set by the
     // SubGraph external default mirror in `7be893a`).
+    //
+    // Use `from_any_typed` so `Domain<_>` / `Mesh` / `BRep` defaults
+    // round-trip — `from_any` only inspects the inner `TypeId` and
+    // therefore cannot recover the domain tag for type-erased
+    // `Arc<dyn Any>` payloads (it returns `Err("Unsupported data
+    // type")` for every non-primitive). The slot's declared
+    // `data_type` is already on hand, so use that.
     let default_ref = input_slot.default_value.as_ref()?;
-    Data::from_any(Arc::clone(default_ref)).ok()
+    Data::from_any_typed(Arc::clone(default_ref), input_slot.data_type).ok()
 }
 
 /// Extract field name/value pairs from a `Data` value for composite types.


### PR DESCRIPTION
## Summary

- Make the executor's `from_any_typed` interface fallback preserve `Domain` and `Mesh` slot defaults instead of dropping the typed payload when only the legacy untyped path is wired.
- Apply rustfmt to the touched module.

## Why

When a node declares a slot as `DataType::Domain(...)` or `DataType::Mesh` and the upstream emits the same typed payload, the existing interface-fallback path was reducing the value to a bare `Any` and re-wrapping, which silently dropped the type tag downstream consumers relied on. The fix keeps the typed payload intact on the fallback path so default routing matches the connected-edge routing.

## Test plan

- [x] `cargo nextest run --lib` on this branch.
- [x] Manual verification via Revion's modeling example — Window/Door variant SubGraphs that route `MaterialRef` / `OpeningPlacement` through SubGraph proxy defaults now propagate the typed payload end-to-end.