### PR TITLE
chore: Unblock wasm32 builds by fixing dependency config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# getrandom 0.3 requires an explicit backend selection for wasm32-unknown-unknown
+# in addition to the `wasm_js` cargo feature (see Cargo.toml target dependencies).
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,17 +40,6 @@ dependencies = [
  "tokio",
  "tracing",
  "ulid",
- "wasm-bindgen",
- "wasm-bindgen-rayon",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -301,7 +290,6 @@ checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
- "wasm_sync",
 ]
 
 [[package]]
@@ -312,7 +300,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
- "wasm_sync",
 ]
 
 [[package]]
@@ -469,7 +456,6 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 
@@ -511,45 +497,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-rayon"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a16c60a56c81e4dc3b9c43d76ba5633e1c0278211d59a9cb07d61b6cd1c6583"
-dependencies = [
- "crossbeam-channel",
- "js-sys",
- "rayon",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm_sync"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff360cade7fec41ff0e9d2cda57fe58258c5f16def0e21302394659e6bbb0ea"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,6 @@ strum = "0.27.0"
 thiserror = "2.0.11"
 tracing = "0.1.41"
 ulid = "1.2.0"
-wasm-bindgen = "0.2.100"
-wasm-bindgen-rayon = "1.3.0"
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = {version = "0.3.1", features = ["wasm_js"]}


### PR DESCRIPTION
## Summary

Makes cognet buildable for wasm32-unknown-unknown, unblocking revion's web support (AltrixHub/revion#232). The unused `wasm-bindgen` / `wasm-bindgen-rayon` dependencies hard-blocked non-atomics wasm builds via `compile_error!`; rayon's documented sequential fallback covers wasm execution.

## Changes

- Remove unused `wasm-bindgen` and `wasm-bindgen-rayon` dependencies (referenced only in doc comments)
- Add `.cargo/config.toml` selecting the getrandom `wasm_js` backend for the wasm32 target (required in addition to the cargo feature)

## Notes

- Consumers embedding cognet as an rlib should pin `codegen-units = 1` for cognet in dev profiles (or reference its registrations): with multiple codegen units, linkers may skip ctor-only archive members and silently drop `inventory` node registrations. revion does this in its workspace profile; verified end-to-end in the browser (104/104 registrations, both collections).