### PR TITLE
feat: Op-log support APIs (deterministic ids, ordered edge queries, indexed port insertion)

### DIFF
--- a/src/node_graph/mod.rs
+++ b/src/node_graph/mod.rs
@@ -301,28 +301,18 @@ impl NodeGraph {
         ns.get_edge(edge_id).cloned()
     }
 
-    /// Get edges connected to an input slot by (node_id, slot_index).
+    /// Get edges connected to an input slot by (node_id, slot_index)
+    /// (ordered). Thin wrapper over
+    /// [`edges_for_input_slot_at`](Self::edges_for_input_slot_at).
     pub fn edges_for_input_slot(&self, node_id: &NodeId, slot: usize) -> Vec<EdgeId> {
-        self.node_states
-            .read()
-            .ok()
-            .and_then(|ns| {
-                let slot_state = ns.input_slot(&NodePath::root().child(*node_id), slot)?;
-                Some(ns.edges_for_input(&slot_state.id).to_vec())
-            })
-            .unwrap_or_default()
+        self.edges_for_input_slot_at(&NodePath::root().child(*node_id), slot)
     }
 
-    /// Get edges connected from a specific output slot (ordered).
+    /// Get edges connected from a specific output slot (ordered). Thin
+    /// wrapper over
+    /// [`edges_for_output_slot_at`](Self::edges_for_output_slot_at).
     pub fn edges_for_output_slot(&self, node_id: &NodeId, slot: usize) -> Vec<EdgeId> {
-        self.node_states
-            .read()
-            .ok()
-            .and_then(|ns| {
-                let slot_state = ns.output_slot(&NodePath::root().child(*node_id), slot)?;
-                Some(ns.edges_for_output(&slot_state.id).to_vec())
-            })
-            .unwrap_or_default()
+        self.edges_for_output_slot_at(&NodePath::root().child(*node_id), slot)
     }
 
     /// Look up the owning `(NodePath, slot_index)` for an `InputSlotId`.

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -912,6 +912,33 @@ impl NodeGraph {
             ns.peek_changed_nodes()
         };
 
+        // Net-removal filter: a node removed AND re-created under the
+        // SAME id since the last execute (e.g. one commit that replaces
+        // the whole graph with a document that reuses the live ids) is
+        // not removed — it exists now and its fresh outputs are part of
+        // this plan. Reporting it in `removed_nodes` would hand
+        // consumers an id that is simultaneously in `node_outputs` and
+        // `removed_nodes`; id-keyed stores cannot order an insertion
+        // against a removal for the same key and would evict the
+        // freshly-computed entry. The contract is therefore:
+        // `removed_nodes` only ever names ids with NO live node at plan
+        // time.
+        let removed: Vec<NodeId> = if removed.is_empty() {
+            removed
+        } else {
+            let live: HashSet<NodeId> = {
+                let ns = self
+                    .node_states
+                    .read()
+                    .map_err(|e| GraphExecutionError::PlanningFailed(e.to_string()))?;
+                ns.node_ids().collect()
+            };
+            removed
+                .into_iter()
+                .filter(|id| !live.contains(id))
+                .collect()
+        };
+
         if changed.is_empty() {
             return Ok(ExecutionPlan {
                 dirty_nodes: HashSet::new(),
@@ -1478,6 +1505,58 @@ mod sync_executor_tests {
         let (graph, _, _, add_id) = build_add_graph(7.0, 8.0);
         let result = graph.execute_sync().unwrap();
         assert_eq!(output_for(&result, add_id), 15.0);
+    }
+
+    /// A plain removal (no re-creation) is reported in `removed_nodes`.
+    #[test]
+    fn plain_removal_is_reported_in_removed_nodes() {
+        let (mut graph, a_id, _, _) = build_add_graph(1.0, 2.0);
+        graph.execute_sync().unwrap();
+
+        graph.remove_node(a_id).unwrap();
+        let result = graph.execute_sync().unwrap();
+        assert!(
+            result.removed_nodes.contains(&a_id),
+            "a removed (not re-created) node must be reported in removed_nodes"
+        );
+    }
+
+    /// Net-removal contract: a node removed AND re-created under the SAME
+    /// id between two executes is NOT reported in `removed_nodes` — it
+    /// exists at plan time and its fresh outputs are part of the result.
+    /// Without this filter an id appears in BOTH `node_outputs` and
+    /// `removed_nodes`, and id-keyed consumer stores (which cannot order
+    /// an insertion against a removal for the same key) evict the
+    /// freshly-computed entry. This is exactly the "replace the whole
+    /// graph with a document that reuses the live ids" load path.
+    #[test]
+    fn removed_then_recreated_same_id_is_not_reported_removed() {
+        let (mut graph, a_id, _, add_id) = build_add_graph(1.0, 2.0);
+        graph.execute_sync().unwrap();
+
+        // One edit cycle: remove `a` and re-create the SAME id.
+        graph.remove_node(a_id).unwrap();
+        graph
+            .create_node_by_name_at_with_id(&NodePath::root(), a_id, "Number")
+            .unwrap();
+        graph
+            .update_node_data(&a_id, Data::new(5.0_f64).unwrap())
+            .unwrap();
+        graph.connect_nodes(&a_id, 0, &add_id, 0).unwrap();
+
+        let result = graph.execute_sync().unwrap();
+        assert!(
+            !result.removed_nodes.contains(&a_id),
+            "a removed-then-recreated id must NOT be reported in removed_nodes \
+             (it is live and present in node_outputs)"
+        );
+        assert!(
+            result
+                .node_outputs
+                .contains_key(&NodePath::root().child(a_id)),
+            "the re-created node's fresh outputs must be part of the result"
+        );
+        assert_eq!(output_for(&result, add_id), 7.0);
     }
 
     #[test]

--- a/src/node_graph/node_graph_system.rs
+++ b/src/node_graph/node_graph_system.rs
@@ -1,4 +1,4 @@
-use crate::{Edge, EdgeId, ErrorTarget, GraphError, NodeGraph, NodePath};
+use crate::{Edge, EdgeId, ErrorTarget, GraphError, NodeGraph, NodeId, NodePath};
 use std::collections::{HashMap, HashSet, VecDeque};
 
 pub(crate) trait NodeGraphSystem {
@@ -8,8 +8,6 @@ pub(crate) trait NodeGraphSystem {
         &self,
         target_paths: &HashSet<NodePath>,
     ) -> Result<Vec<Vec<NodePath>>, String>;
-
-    fn add_edge(&mut self, edge: Edge) -> Result<EdgeId, String>;
 }
 
 impl NodeGraphSystem for NodeGraph {
@@ -85,9 +83,20 @@ impl NodeGraphSystem for NodeGraph {
 
         Ok(sorted)
     }
+}
 
-    fn add_edge(&mut self, mut edge: Edge) -> Result<EdgeId, String> {
-        tracing::debug!("[cognet] add_edge: START");
+impl NodeGraph {
+    /// Insert a pre-built `Edge` under the caller-provided `edge_id`.
+    ///
+    /// Core edge-insertion routine: [`connect_nodes_at_with_id`] builds the
+    /// `Edge` and delegates here, and [`connect_nodes_at`] mints a fresh
+    /// `EdgeId` before doing the same. Callers that need deterministic ids
+    /// (op-log replay, save/load) hand in the id here. Runs the full slot /
+    /// type / connection-limit validation and additionally rejects an
+    /// `edge_id` that is already present, so a duplicate op cannot silently
+    /// overwrite an edge.
+    pub fn add_edge_with_id(&mut self, edge_id: EdgeId, mut edge: Edge) -> Result<EdgeId, String> {
+        tracing::debug!("[cognet] add_edge_with_id: START");
 
         // SubGraph external slots are an alias surface for the
         // InputProxy / OutputProxy InterfaceNode slots inside the
@@ -112,7 +121,7 @@ impl NodeGraphSystem for NodeGraph {
                 ns.input_slot(&proxy_path, edge.to_input_slot_index)
                     .ok_or_else(|| {
                         format!(
-                            "add_edge: InputProxy at {proxy_path} has no input slot \
+                            "add_edge_with_id: InputProxy at {proxy_path} has no input slot \
                              {} (SubGraph external slot exists but the proxy is missing \
                              it — schema mismatch)",
                             edge.to_input_slot_index
@@ -130,7 +139,7 @@ impl NodeGraphSystem for NodeGraph {
                 ns.output_slot(&proxy_path, edge.from_output_slot_index)
                     .ok_or_else(|| {
                         format!(
-                            "add_edge: OutputProxy at {proxy_path} has no output slot \
+                            "add_edge_with_id: OutputProxy at {proxy_path} has no output slot \
                              {} (SubGraph external slot exists but the proxy is missing \
                              it — schema mismatch)",
                             edge.from_output_slot_index
@@ -148,10 +157,10 @@ impl NodeGraphSystem for NodeGraph {
         // non-root paths; root-level nodes have a single-element path.
         let from_node_id = from_node
             .leaf()
-            .ok_or_else(|| "add_edge: from_node is a root path".to_string())?;
+            .ok_or_else(|| "add_edge_with_id: from_node is a root path".to_string())?;
         let to_node_id = to_node
             .leaf()
-            .ok_or_else(|| "add_edge: to_node is a root path".to_string())?;
+            .ok_or_else(|| "add_edge_with_id: to_node is a root path".to_string())?;
 
         // Clear previous errors for the target input port
         let input_target = ErrorTarget::InputPort {
@@ -235,11 +244,16 @@ impl NodeGraphSystem for NodeGraph {
             }
         }
 
-        let edge_id = EdgeId::new();
-
-        // Update NodeStates (edge storage + indexes + auto-tracks changed)
+        // Update NodeStates (edge storage + indexes + auto-tracks changed).
+        // Reject a duplicate id first so replay of a malformed op-log cannot
+        // clobber an existing edge under the same id.
         {
             let mut guard = self.node_states.write().map_err(|e| e.to_string())?;
+            if guard.get_edge(&edge_id).is_some() {
+                return Err(format!(
+                    "add_edge_with_id: edge id {edge_id:?} already exists"
+                ));
+            }
             guard.add_edge(edge_id, edge.clone());
         }
 
@@ -260,7 +274,7 @@ impl NodeGraph {
     ///
     /// Resolves the slot ids for both endpoints from `NodeStates`. The
     /// returned `Edge` is not added to the graph; pass it to
-    /// [`NodeGraphSystem::add_edge`] (or use [`connect_nodes_at`] which
+    /// [`add_edge_with_id`] (or use [`connect_nodes_at`] which
     /// does both).
     pub fn create_edge_at(
         &self,
@@ -300,11 +314,32 @@ impl NodeGraph {
     }
 
     /// Connect two nodes identified by `NodePath`. Path-aware sibling of
-    /// [`NodeGraphWrite::connect_nodes`]; builds the `Edge` via
-    /// [`create_edge_at`] and inserts it via
-    /// [`NodeGraphSystem::add_edge`].
+    /// [`NodeGraphWrite::connect_nodes`]; mints a fresh `EdgeId` and
+    /// delegates to [`connect_nodes_at_with_id`].
     pub fn connect_nodes_at(
         &mut self,
+        from_path: &NodePath,
+        from_output_slot_index: usize,
+        to_path: &NodePath,
+        to_input_slot_index: usize,
+    ) -> Result<EdgeId, String> {
+        self.connect_nodes_at_with_id(
+            EdgeId::new(),
+            from_path,
+            from_output_slot_index,
+            to_path,
+            to_input_slot_index,
+        )
+    }
+
+    /// Connect two `NodePath` endpoints under the caller-provided `edge_id`.
+    /// Id-parameterized sibling of [`connect_nodes_at`]; the no-id variant
+    /// mints a fresh id and delegates here. Same validation as
+    /// `connect_nodes_at`, and rejects a duplicate `edge_id` (see
+    /// [`add_edge_with_id`]).
+    pub fn connect_nodes_at_with_id(
+        &mut self,
+        edge_id: EdgeId,
         from_path: &NodePath,
         from_output_slot_index: usize,
         to_path: &NodePath,
@@ -319,7 +354,28 @@ impl NodeGraph {
             )
             .map_err(|e| e.to_string())?;
 
-        self.add_edge(edge)
+        self.add_edge_with_id(edge_id, edge)
+    }
+
+    /// Connect two root-level nodes under the caller-provided `edge_id`.
+    /// Root-path wrapper over [`connect_nodes_at_with_id`], mirroring how
+    /// [`NodeGraphWrite::connect_nodes`] wraps [`connect_nodes_at`]. This is
+    /// the deterministic-id entry point used by op-log replay and save/load.
+    pub fn connect_with_id(
+        &mut self,
+        edge_id: EdgeId,
+        from: NodeId,
+        from_output_slot_index: usize,
+        to: NodeId,
+        to_input_slot_index: usize,
+    ) -> Result<EdgeId, String> {
+        self.connect_nodes_at_with_id(
+            edge_id,
+            &NodePath::root().child(from),
+            from_output_slot_index,
+            &NodePath::root().child(to),
+            to_input_slot_index,
+        )
     }
 }
 
@@ -371,6 +427,48 @@ mod path_aware_edge_tests {
         let edge = graph.get_edge_by_id(&edge_id).expect("edge exists");
         assert_eq!(edge.from_node, NodePath::root().child(num_id));
         assert_eq!(edge.to_node, NodePath::root().child(add_id));
+    }
+
+    #[test]
+    fn connect_with_id_uses_given_id() {
+        use crate::EdgeId;
+
+        let mut graph = NodeGraph::new().expect("create graph");
+        let num_id = graph.create_node_by_name("Number").expect("create num");
+        let add_id = graph.create_node_by_name("Add").expect("create add");
+
+        // Caller pre-generates the id; the connect must honour it verbatim.
+        let given = EdgeId::new();
+        let returned = graph
+            .connect_with_id(given, num_id, 0, add_id, 0)
+            .expect("connect_with_id");
+
+        assert_eq!(returned, given, "connect_with_id must return the given id");
+        assert!(
+            graph.get_edge_by_id(&given).is_some(),
+            "edge must be stored under the caller-pregenerated id",
+        );
+    }
+
+    #[test]
+    fn connect_with_id_rejects_duplicate_id() {
+        use crate::EdgeId;
+
+        let mut graph = NodeGraph::new().expect("create graph");
+        let num_id = graph.create_node_by_name("Number").expect("create num");
+        let add_id = graph.create_node_by_name("Add").expect("create add");
+
+        let given = EdgeId::new();
+        graph
+            .connect_with_id(given, num_id, 0, add_id, 0)
+            .expect("first connect_with_id");
+
+        // Reusing the same id for a distinct, otherwise-valid edge must fail.
+        let err = graph.connect_with_id(given, num_id, 0, add_id, 1);
+        assert!(
+            err.is_err(),
+            "connect_with_id must reject a duplicate edge id, got {err:?}",
+        );
     }
 }
 

--- a/src/node_graph/node_state.rs
+++ b/src/node_graph/node_state.rs
@@ -194,6 +194,96 @@ impl NodeStates {
         index
     }
 
+    /// Insert a dynamic input slot at `index`, shifting higher-indexed
+    /// slots up. Mirror of [`Self::remove_input_slot`], used to restore
+    /// a removed slot at its original position (op-log undo).
+    ///
+    /// Edges referencing this node's input slots at `index` or above
+    /// have their `to_input_slot_index` incremented so they keep
+    /// pointing at the same logical slot. `index` is clamped to the
+    /// current count (clamped insert == append); public `NodeGraph`
+    /// wrappers validate the range and return `Err` before calling in.
+    pub fn insert_input_slot_at(
+        &mut self,
+        path: &NodePath,
+        index: usize,
+        label: &'static str,
+        data_type: DataType,
+        max_connections: Option<usize>,
+        inspector_visible: bool,
+    ) -> usize {
+        let count = self.input_slot_count(path);
+        let index = index.min(count);
+        // Shift slots [index..count) up by 1, top-down, updating
+        // reverse-owner indices.
+        for i in (index..count).rev() {
+            if let Some(slot) = self.input_slots.remove(&(path.clone(), i)) {
+                self.input_slot_owner.insert(slot.id, (path.clone(), i + 1));
+                self.input_slots.insert((path.clone(), i + 1), slot);
+            }
+        }
+        let slot = InputSlotState {
+            id: InputSlotId::new(),
+            label,
+            data_type,
+            max_connections,
+            inspector_visible,
+            default_value: None,
+        };
+        self.input_slot_owner.insert(slot.id, (path.clone(), index));
+        self.input_slots.insert((path.clone(), index), slot);
+        // Increment to_input_slot_index on edges referencing shifted
+        // slots so indices stay aligned (mirror of remove's decrement).
+        for edge in self.edges.values_mut() {
+            if edge.to_node == *path && edge.to_input_slot_index >= index {
+                edge.to_input_slot_index += 1;
+                if let Some(entry) = self.input_slot_owner.get_mut(&edge.to_input_slot_id) {
+                    entry.1 = edge.to_input_slot_index;
+                }
+            }
+        }
+        index
+    }
+
+    /// Insert a dynamic output slot at `index`, shifting higher-indexed
+    /// slots up. Mirror of [`Self::remove_output_slot`]; see
+    /// [`Self::insert_input_slot_at`] for the shift / edge-remap
+    /// contract.
+    pub fn insert_output_slot_at(
+        &mut self,
+        path: &NodePath,
+        index: usize,
+        label: &'static str,
+        data_type: DataType,
+    ) -> usize {
+        let count = self.output_slot_count(path);
+        let index = index.min(count);
+        for i in (index..count).rev() {
+            if let Some(slot) = self.output_slots.remove(&(path.clone(), i)) {
+                self.output_slot_owner
+                    .insert(slot.id, (path.clone(), i + 1));
+                self.output_slots.insert((path.clone(), i + 1), slot);
+            }
+        }
+        let slot = OutputSlotState {
+            id: OutputSlotId::new(),
+            label,
+            data_type,
+        };
+        self.output_slot_owner
+            .insert(slot.id, (path.clone(), index));
+        self.output_slots.insert((path.clone(), index), slot);
+        for edge in self.edges.values_mut() {
+            if edge.from_node == *path && edge.from_output_slot_index >= index {
+                edge.from_output_slot_index += 1;
+                if let Some(entry) = self.output_slot_owner.get_mut(&edge.from_output_slot_id) {
+                    entry.1 = edge.from_output_slot_index;
+                }
+            }
+        }
+        index
+    }
+
     /// Rewrite the `inspector_visible` flag of an input slot. Returns
     /// `true` on success, `false` if the slot does not exist.
     pub fn set_input_slot_inspector_visible(

--- a/src/node_graph/path_api.rs
+++ b/src/node_graph/path_api.rs
@@ -184,6 +184,38 @@ impl NodeGraph {
         ns.input_slot(path, slot).map(|s| s.data_type)
     }
 
+    /// Get the **ordered** edge list connected to an input slot at
+    /// `path`. Path-aware sibling of
+    /// [`NodeGraph::edges_for_input_slot`]; the root variant is a thin
+    /// wrapper over this method. The order is the slot's connection
+    /// order (semantic for variable-length inputs such as polyline
+    /// points), matching [`NodeStates::edges_for_input`].
+    pub fn edges_for_input_slot_at(&self, path: &NodePath, slot: usize) -> Vec<crate::EdgeId> {
+        self.node_states
+            .read()
+            .ok()
+            .and_then(|ns| {
+                let slot_state = ns.input_slot(path, slot)?;
+                Some(ns.edges_for_input(&slot_state.id).to_vec())
+            })
+            .unwrap_or_default()
+    }
+
+    /// Get the **ordered** edge list connected from an output slot at
+    /// `path`. Path-aware sibling of
+    /// [`NodeGraph::edges_for_output_slot`]; the root variant is a
+    /// thin wrapper over this method.
+    pub fn edges_for_output_slot_at(&self, path: &NodePath, slot: usize) -> Vec<crate::EdgeId> {
+        self.node_states
+            .read()
+            .ok()
+            .and_then(|ns| {
+                let slot_state = ns.output_slot(path, slot)?;
+                Some(ns.edges_for_output(&slot_state.id).to_vec())
+            })
+            .unwrap_or_default()
+    }
+
     /// Whether an input slot should be rendered as an editable row by
     /// downstream property inspectors. Returns `None` when the slot does
     /// not exist; callers may treat that as visible.
@@ -1420,6 +1452,68 @@ mod tests {
         assert_eq!(
             graph.input_slot_data_type_at(&add_path, 0),
             Some(crate::DataType::Number),
+        );
+    }
+
+    #[test]
+    fn edges_for_input_slot_at_depth_2_returns_connect_order() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let sg_id = graph
+            .add_subgraph_at(&crate::NodePath::root(), "SG")
+            .expect("add_subgraph_at");
+        let sg_path = crate::NodePath::root().child(sg_id);
+        let add_id = graph
+            .create_node_by_name_at(&sg_path, "AddList")
+            .expect("create AddList");
+        let n1 = graph
+            .create_node_by_name_at(&sg_path, "Number")
+            .expect("create Number 1");
+        let n2 = graph
+            .create_node_by_name_at(&sg_path, "Number")
+            .expect("create Number 2");
+        let add_path = sg_path.child(add_id);
+        let e1 = graph
+            .connect_nodes_at(&sg_path.child(n1), 0, &add_path, 0)
+            .expect("connect n1");
+        let e2 = graph
+            .connect_nodes_at(&sg_path.child(n2), 0, &add_path, 0)
+            .expect("connect n2");
+
+        assert_eq!(
+            graph.edges_for_input_slot_at(&add_path, 0),
+            vec![e1, e2],
+            "path-aware input-slot edge list must preserve connect order at depth-2",
+        );
+    }
+
+    #[test]
+    fn edges_for_output_slot_at_depth_2_returns_connect_order() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let sg_id = graph
+            .add_subgraph_at(&crate::NodePath::root(), "SG")
+            .expect("add_subgraph_at");
+        let sg_path = crate::NodePath::root().child(sg_id);
+        let num_id = graph
+            .create_node_by_name_at(&sg_path, "Number")
+            .expect("create Number");
+        let a1 = graph
+            .create_node_by_name_at(&sg_path, "Add")
+            .expect("create Add 1");
+        let a2 = graph
+            .create_node_by_name_at(&sg_path, "Add")
+            .expect("create Add 2");
+        let num_path = sg_path.child(num_id);
+        let e1 = graph
+            .connect_nodes_at(&num_path, 0, &sg_path.child(a1), 0)
+            .expect("connect a1");
+        let e2 = graph
+            .connect_nodes_at(&num_path, 0, &sg_path.child(a2), 0)
+            .expect("connect a2");
+
+        assert_eq!(
+            graph.edges_for_output_slot_at(&num_path, 0),
+            vec![e1, e2],
+            "path-aware output-slot edge list must preserve connect order at depth-2",
         );
     }
 

--- a/src/node_graph/path_api.rs
+++ b/src/node_graph/path_api.rs
@@ -524,6 +524,67 @@ impl NodeGraph {
         Ok(())
     }
 
+    /// Clear the default value of input slot `slot_index` at `path`
+    /// (reset it to `None`). Companion to
+    /// [`update_input_slot_default_data_at`](Self::update_input_slot_default_data_at)
+    /// with the same SubGraph-proxy mirror, atomicity, and dirty
+    /// contract. Added for op-log inverse support: the inverse of
+    /// setting a value over an absent prior default must reproduce
+    /// absence.
+    ///
+    /// Clearing an already-absent default is a no-op `Ok` — inverse
+    /// sequences are replayed blindly, so the clear is idempotent. A
+    /// missing slot is still a typed `Err`.
+    pub fn clear_input_slot_default_data_at(
+        &mut self,
+        path: &NodePath,
+        slot_index: usize,
+    ) -> Result<(), String> {
+        // Resolve proxy WITHOUT mutating; None = path is not a SubGraph,
+        // so the mirror is skipped (same shape as the update sibling).
+        let proxy_path = self
+            .subgraph_proxy_ids_at_path(path)
+            .map(|(input_proxy_id, _)| path.child(input_proxy_id));
+
+        let mut guard = self.node_states.write().map_err(|e| e.to_string())?;
+
+        // Pre-validate ALL targets before mutating (atomicity invariant).
+        if guard.input_slot(path, slot_index).is_none() {
+            return Err(format!(
+                "clear_input_slot_default_data_at: slot {} not found at path {}",
+                slot_index, path
+            ));
+        }
+        if let Some(ref ppath) = proxy_path {
+            if guard.input_slot(ppath, slot_index).is_none() {
+                return Err(format!(
+                    "clear_input_slot_default_data_at: InputProxy missing slot {} \
+                     for SubGraph at {}",
+                    slot_index, path
+                ));
+            }
+        }
+
+        // Atomic mutate.
+        guard
+            .input_slot_mut(path, slot_index)
+            .expect("validated above")
+            .default_value = None;
+        if let Some(ref ppath) = proxy_path {
+            guard
+                .input_slot_mut(ppath, slot_index)
+                .expect("validated above")
+                .default_value = None;
+        }
+
+        // Dirty BOTH paths — see plan-010 §3.7.
+        guard.mark_changed(path);
+        if let Some(ppath) = proxy_path {
+            guard.mark_changed(&ppath);
+        }
+        Ok(())
+    }
+
     /// Replace a single field of the node-data payload at `path`.
     /// Path-aware sibling of
     /// [`NodeGraphWrite::update_node_data_field`]; the root variant is
@@ -1140,6 +1201,125 @@ mod tests {
             .downcast_ref::<crate::Vector3>()
             .expect("Vector3 default value");
         assert_eq!((v.x, v.y, v.z), (0.0, 0.0, -4.5));
+    }
+
+    // ── clear_input_slot_default_data_at (op-log inverse support) ──
+
+    /// set → clear → the slot's default is `None` again and the path is
+    /// marked changed. This is the plain-node absence-restoring inverse
+    /// the app's op-log needs for `SetInputValue` over an absent prior.
+    #[test]
+    fn clear_input_slot_default_data_at_resets_default_to_none() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let add_id = graph
+            .create_node_by_name_at(&crate::NodePath::root(), "Add")
+            .expect("create Add");
+        let add_path = crate::NodePath::root().child(add_id);
+
+        graph
+            .update_input_slot_default_data_at(
+                &add_path,
+                0,
+                crate::Data::new(4.0_f64).expect("Data::new"),
+            )
+            .expect("seed default");
+        // Drain the change set so the clear's own dirty mark is visible.
+        {
+            let mut ns = graph.node_states.write().expect("write ns");
+            let _ = ns.drain_changed_nodes();
+        }
+
+        graph
+            .clear_input_slot_default_data_at(&add_path, 0)
+            .expect("clear default");
+
+        let ns = graph.node_states.read().expect("read ns");
+        assert!(
+            ns.input_slot(&add_path, 0).unwrap().default_value.is_none(),
+            "default must be None after clear",
+        );
+        assert!(
+            ns.peek_changed_nodes().contains(&add_path),
+            "clear must mark the path changed",
+        );
+    }
+
+    /// Clearing an already-absent default is a no-op `Ok` — the op-log
+    /// replays inverse sequences blindly, so an idempotent clear must
+    /// not error.
+    #[test]
+    fn clear_input_slot_default_data_at_over_absent_is_noop_ok() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let add_id = graph
+            .create_node_by_name_at(&crate::NodePath::root(), "Add")
+            .expect("create Add");
+        let add_path = crate::NodePath::root().child(add_id);
+
+        graph
+            .clear_input_slot_default_data_at(&add_path, 0)
+            .expect("clear over absent default must be Ok");
+
+        let ns = graph.node_states.read().expect("read ns");
+        assert!(
+            ns.input_slot(&add_path, 0).unwrap().default_value.is_none(),
+            "default stays None",
+        );
+    }
+
+    /// Missing slot → typed Err (mirrors the update sibling).
+    #[test]
+    fn clear_input_slot_default_data_at_errs_on_missing_slot() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let add_id = graph
+            .create_node_by_name_at(&crate::NodePath::root(), "Add")
+            .expect("create Add");
+        let add_path = crate::NodePath::root().child(add_id);
+
+        let err = graph
+            .clear_input_slot_default_data_at(&add_path, 99)
+            .expect_err("slot 99 does not exist");
+        assert!(err.contains("slot 99"), "error names the slot: {err}");
+    }
+
+    /// When the path resolves to a SubGraph node, the clear is mirrored
+    /// onto the InputProxy's input slot too (same contract as the
+    /// update sibling, plan-010 §3.7).
+    #[test]
+    fn clear_input_slot_default_data_at_mirrors_to_proxy_when_target_is_subgraph() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let sg_id = graph
+            .add_subgraph_at(&crate::NodePath::root(), "SG")
+            .expect("add_subgraph_at");
+        graph
+            .add_subgraph_input(&sg_id, "x", crate::DataType::Number)
+            .expect("add input");
+        let sg_path = crate::NodePath::root().child(sg_id);
+        graph
+            .update_input_slot_default_data_at(
+                &sg_path,
+                0,
+                crate::Data::new(13.0_f64).expect("Data::new"),
+            )
+            .expect("seed default");
+
+        graph
+            .clear_input_slot_default_data_at(&sg_path, 0)
+            .expect("clear default");
+
+        let (input_proxy_id, _) = graph.subgraph_proxy_ids(&sg_id).expect("proxy ids");
+        let proxy_path = sg_path.child(input_proxy_id);
+        let ns = graph.node_states.read().expect("read");
+        assert!(
+            ns.input_slot(&sg_path, 0).unwrap().default_value.is_none(),
+            "external default cleared",
+        );
+        assert!(
+            ns.input_slot(&proxy_path, 0)
+                .unwrap()
+                .default_value
+                .is_none(),
+            "proxy default cleared too",
+        );
     }
 
     #[test]

--- a/src/node_graph/subgraph_helpers.rs
+++ b/src/node_graph/subgraph_helpers.rs
@@ -153,6 +153,37 @@ impl NodeGraph {
         Ok(())
     }
 
+    /// Insert an input port on a SubGraphNode at `index`, shifting
+    /// higher-indexed ports up. Index-parameterized sibling of
+    /// [`Self::add_subgraph_input`] (`index == count` appends); used to
+    /// restore a removed port at its original position (op-log undo).
+    /// Returns `Err` when `index` exceeds the current port count.
+    pub fn insert_subgraph_input_at(
+        &self,
+        node_id: &NodeId,
+        index: usize,
+        label: &'static str,
+        data_type: DataType,
+    ) -> Result<(), String> {
+        let (input_proxy_id, _) = self
+            .subgraph_proxy_ids(node_id)
+            .ok_or_else(|| format!("Node {:?} is not a SubGraphNode", node_id))?;
+        let sg_path = NodePath::root().child(*node_id);
+        let in_path = sg_path.child(input_proxy_id);
+        let mut ns = self.node_states.write().map_err(|e| e.to_string())?;
+        let count = ns.input_slot_count(&in_path);
+        if index > count {
+            return Err(format!(
+                "insert_subgraph_input_at: index {index} out of range (count {count})"
+            ));
+        }
+        ns.insert_input_slot_at(&in_path, index, label, data_type, Some(1), true);
+        ns.insert_output_slot_at(&in_path, index, label, data_type);
+        // Sync external slot on parent SubGraphNode.
+        ns.insert_input_slot_at(&sg_path, index, label, data_type, None, true);
+        Ok(())
+    }
+
     /// Remove an input port from a SubGraphNode by index.
     pub fn remove_subgraph_input(&self, node_id: &NodeId, index: usize) -> Result<(), String> {
         let (input_proxy_id, _) = self
@@ -223,6 +254,36 @@ impl NodeGraph {
         ns.add_output_slot(&out_path, label, data_type);
         // Sync external slot on parent SubGraphNode.
         ns.add_output_slot(&NodePath::root().child(*node_id), label, data_type);
+        Ok(())
+    }
+
+    /// Insert an output port on a SubGraphNode at `index`, shifting
+    /// higher-indexed ports up. Index-parameterized sibling of
+    /// [`Self::add_subgraph_output`]; see
+    /// [`Self::insert_subgraph_input_at`] for the range contract.
+    pub fn insert_subgraph_output_at(
+        &self,
+        node_id: &NodeId,
+        index: usize,
+        label: &'static str,
+        data_type: DataType,
+    ) -> Result<(), String> {
+        let (_, output_proxy_id) = self
+            .subgraph_proxy_ids(node_id)
+            .ok_or_else(|| format!("Node {:?} is not a SubGraphNode", node_id))?;
+        let sg_path = NodePath::root().child(*node_id);
+        let out_path = sg_path.child(output_proxy_id);
+        let mut ns = self.node_states.write().map_err(|e| e.to_string())?;
+        let count = ns.input_slot_count(&out_path);
+        if index > count {
+            return Err(format!(
+                "insert_subgraph_output_at: index {index} out of range (count {count})"
+            ));
+        }
+        ns.insert_input_slot_at(&out_path, index, label, data_type, None, true);
+        ns.insert_output_slot_at(&out_path, index, label, data_type);
+        // Sync external slot on parent SubGraphNode.
+        ns.insert_output_slot_at(&sg_path, index, label, data_type);
         Ok(())
     }
 
@@ -300,6 +361,44 @@ impl NodeGraph {
         data_type: DataType,
     ) -> Result<(), String> {
         self.add_subgraph_output(node_id, label, data_type)?;
+        let (_, output_proxy_id) = self
+            .subgraph_proxy_ids(node_id)
+            .ok_or("Node is not a SubGraphNode")?;
+        let sg_path = NodePath::root().child(*node_id);
+        let out_path = sg_path.child(output_proxy_id);
+        append_locked_label_at(self, &out_path, label)?;
+        Ok(())
+    }
+
+    /// Insert a **locked** input port on a SubGraphNode at `index`.
+    /// Locked sibling of [`Self::insert_subgraph_input_at`].
+    pub fn insert_subgraph_input_locked_at(
+        &self,
+        node_id: &NodeId,
+        index: usize,
+        label: &'static str,
+        data_type: DataType,
+    ) -> Result<(), String> {
+        self.insert_subgraph_input_at(node_id, index, label, data_type)?;
+        let (input_proxy_id, _) = self
+            .subgraph_proxy_ids(node_id)
+            .ok_or("Node is not a SubGraphNode")?;
+        let sg_path = NodePath::root().child(*node_id);
+        let in_path = sg_path.child(input_proxy_id);
+        append_locked_label_at(self, &in_path, label)?;
+        Ok(())
+    }
+
+    /// Insert a **locked** output port on a SubGraphNode at `index`.
+    /// Locked sibling of [`Self::insert_subgraph_output_at`].
+    pub fn insert_subgraph_output_locked_at(
+        &self,
+        node_id: &NodeId,
+        index: usize,
+        label: &'static str,
+        data_type: DataType,
+    ) -> Result<(), String> {
+        self.insert_subgraph_output_at(node_id, index, label, data_type)?;
         let (_, output_proxy_id) = self
             .subgraph_proxy_ids(node_id)
             .ok_or("Node is not a SubGraphNode")?;
@@ -881,6 +980,213 @@ mod tests {
         assert!(
             dirty.contains(&proxy_path),
             "proxy_path must be dirty (internals re-execute trigger)"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // insert_subgraph_input_at / insert_subgraph_output_at
+    // (index-parameterized port revival for op-log undo)
+    // -----------------------------------------------------------------
+
+    /// Ordered input-slot labels of the node at `path`.
+    fn input_labels_at(graph: &crate::NodeGraph, path: &crate::NodePath) -> Vec<&'static str> {
+        let ns = graph.node_states().read().expect("read");
+        let count = ns.input_slot_count(path);
+        (0..count)
+            .map(|i| ns.input_slot(path, i).expect("slot").label)
+            .collect()
+    }
+
+    /// Ordered output-slot labels of the node at `path`.
+    fn output_labels_at(graph: &crate::NodeGraph, path: &crate::NodePath) -> Vec<&'static str> {
+        let ns = graph.node_states().read().expect("read");
+        let count = ns.output_slot_count(path);
+        (0..count)
+            .map(|i| ns.output_slot(path, i).expect("slot").label)
+            .collect()
+    }
+
+    /// Removing the MIDDLE input port and re-inserting it at its old
+    /// index must restore the original ordered label list on the parent
+    /// SubGraphNode AND on both proxy slot lists.
+    #[test]
+    fn insert_subgraph_input_at_restores_middle_position() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let sg = graph
+            .add_subgraph_at(&crate::NodePath::root(), "Test")
+            .expect("create subgraph");
+        for label in ["a", "b", "c"] {
+            graph
+                .add_subgraph_input(&sg, label, DataType::Number)
+                .expect("add input");
+        }
+
+        graph.remove_subgraph_input(&sg, 1).expect("remove middle");
+        graph
+            .insert_subgraph_input_at(&sg, 1, "b", DataType::Number)
+            .expect("insert at 1");
+
+        let sg_path = crate::NodePath::root().child(sg);
+        let (input_proxy_id, _) = graph.subgraph_proxy_ids(&sg).expect("proxy ids");
+        let in_path = sg_path.child(input_proxy_id);
+        assert_eq!(input_labels_at(&graph, &sg_path), vec!["a", "b", "c"]);
+        assert_eq!(input_labels_at(&graph, &in_path), vec!["a", "b", "c"]);
+        assert_eq!(output_labels_at(&graph, &in_path), vec!["a", "b", "c"]);
+    }
+
+    /// Inserting below an occupied slot must shift the edges wired to
+    /// higher slots up so they keep pointing at the same logical port.
+    #[test]
+    fn insert_subgraph_input_at_shifts_higher_slot_edges_up() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let sg = graph
+            .add_subgraph_at(&crate::NodePath::root(), "Test")
+            .expect("create subgraph");
+        for label in ["a", "b"] {
+            graph
+                .add_subgraph_input(&sg, label, DataType::Number)
+                .expect("add input");
+        }
+        let feeder = graph
+            .create_node::<crate::NumberNode>()
+            .expect("create feeder");
+        let edge = graph.connect_nodes(&feeder, 0, &sg, 1).expect("wire b");
+
+        // Remove "a" (index 0): b's edge index decrements to 0.
+        graph.remove_subgraph_input(&sg, 0).expect("remove a");
+        // Re-insert "a" at 0: b's edge index must shift back to 1.
+        graph
+            .insert_subgraph_input_at(&sg, 0, "a", DataType::Number)
+            .expect("insert at 0");
+
+        let ns = graph.node_states().read().expect("read");
+        let e = ns.get_edge(&edge).expect("edge survives");
+        assert_eq!(
+            e.to_input_slot_index, 1,
+            "edge into 'b' must follow its slot back up to index 1"
+        );
+    }
+
+    /// Out-of-range index is rejected with Err; index == count appends.
+    #[test]
+    fn insert_subgraph_input_at_validates_index() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let sg = graph
+            .add_subgraph_at(&crate::NodePath::root(), "Test")
+            .expect("create subgraph");
+        graph
+            .add_subgraph_input(&sg, "a", DataType::Number)
+            .expect("add input");
+
+        let err = graph
+            .insert_subgraph_input_at(&sg, 2, "x", DataType::Number)
+            .expect_err("index 2 > count 1 must Err");
+        assert!(err.contains("out of range"), "unexpected error: {err}");
+
+        graph
+            .insert_subgraph_input_at(&sg, 1, "b", DataType::Number)
+            .expect("index == count appends");
+        let sg_path = crate::NodePath::root().child(sg);
+        assert_eq!(input_labels_at(&graph, &sg_path), vec!["a", "b"]);
+    }
+
+    /// Output-side mirror of the middle-position restore.
+    #[test]
+    fn insert_subgraph_output_at_restores_middle_position() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let sg = graph
+            .add_subgraph_at(&crate::NodePath::root(), "Test")
+            .expect("create subgraph");
+        for label in ["a", "b", "c"] {
+            graph
+                .add_subgraph_output(&sg, label, DataType::Number)
+                .expect("add output");
+        }
+
+        graph.remove_subgraph_output(&sg, 1).expect("remove middle");
+        graph
+            .insert_subgraph_output_at(&sg, 1, "b", DataType::Number)
+            .expect("insert at 1");
+
+        let sg_path = crate::NodePath::root().child(sg);
+        let (_, output_proxy_id) = graph.subgraph_proxy_ids(&sg).expect("proxy ids");
+        let out_path = sg_path.child(output_proxy_id);
+        assert_eq!(output_labels_at(&graph, &sg_path), vec!["a", "b", "c"]);
+        assert_eq!(input_labels_at(&graph, &out_path), vec!["a", "b", "c"]);
+        assert_eq!(output_labels_at(&graph, &out_path), vec!["a", "b", "c"]);
+    }
+
+    /// Output-side edge shift mirror: an external edge from the
+    /// SubGraph's higher output slot follows its slot up on insert.
+    #[test]
+    fn insert_subgraph_output_at_shifts_higher_slot_edges_up() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let sg = graph
+            .add_subgraph_at(&crate::NodePath::root(), "Test")
+            .expect("create subgraph");
+        for label in ["a", "b"] {
+            graph
+                .add_subgraph_output(&sg, label, DataType::Number)
+                .expect("add output");
+        }
+        let sink = graph.create_node::<crate::AddNode>().expect("create sink");
+        let edge = graph.connect_nodes(&sg, 1, &sink, 0).expect("wire b out");
+
+        graph.remove_subgraph_output(&sg, 0).expect("remove a");
+        graph
+            .insert_subgraph_output_at(&sg, 0, "a", DataType::Number)
+            .expect("insert at 0");
+
+        let ns = graph.node_states().read().expect("read");
+        let e = ns.get_edge(&edge).expect("edge survives");
+        assert_eq!(
+            e.from_output_slot_index, 1,
+            "edge from 'b' must follow its slot back up to index 1"
+        );
+    }
+
+    /// Locked insert variants stamp `InterfaceNodeData.locked` exactly
+    /// like the append-style `add_subgraph_*_locked`.
+    #[test]
+    fn insert_subgraph_port_locked_at_stamps_lock() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let sg = graph
+            .add_subgraph_at(&crate::NodePath::root(), "Test")
+            .expect("create subgraph");
+        graph
+            .add_subgraph_input(&sg, "a", DataType::Number)
+            .expect("add input");
+        graph
+            .add_subgraph_output(&sg, "x", DataType::Number)
+            .expect("add output");
+
+        graph
+            .insert_subgraph_input_locked_at(&sg, 0, "mand_in", DataType::Number)
+            .expect("locked input insert");
+        graph
+            .insert_subgraph_output_locked_at(&sg, 0, "mand_out", DataType::Number)
+            .expect("locked output insert");
+
+        let sg_path = crate::NodePath::root().child(sg);
+        assert_eq!(input_labels_at(&graph, &sg_path), vec!["mand_in", "a"]);
+        assert_eq!(output_labels_at(&graph, &sg_path), vec!["mand_out", "x"]);
+
+        let (in_proxy, out_proxy) = graph.subgraph_proxy_ids(&sg).expect("proxy ids");
+        let locked_of = |proxy: crate::NodeId| {
+            let ns = graph.node_states().read().expect("read");
+            ns.get(&sg_path.child(proxy))
+                .and_then(|s| s.data.as_ref())
+                .and_then(|d| d.value::<crate::InterfaceNodeData>().ok().cloned())
+                .map(|d| d.locked)
+                .unwrap_or_default()
+        };
+        assert!(
+            locked_of(in_proxy).contains("mand_in"),
+            "input lock stamped"
+        );
+        assert!(
+            locked_of(out_proxy).contains("mand_out"),
+            "output lock stamped"
         );
     }
 }


### PR DESCRIPTION
## Summary

Support APIs for revion's op-log architecture (project persistence + undo/redo — companion revion PR follows). All additions mirror existing API conventions and are consumed by revion's `feat/graph-oplog` branch.

- **`connect_with_id`** — connect with a caller-supplied `EdgeId` (deterministic replay requires all ids to be pre-generated by the caller). Rejects duplicate ids at the storage boundary.
- **`clear_input_slot_default_data_at`** — plain-node input default clear (mirrors `clear_subgraph_input_default`; needed to restore *absence* when undoing a first `SetInputValue`). Proxy-mirroring, atomic, idempotent over absence.
- **`edges_for_input_slot_at` / `edges_for_output_slot_at`** — path-aware ordered per-slot edge queries (undo must capture and restore cognet's semantic per-slot connection order).
- **`insert_subgraph_input_at` / `insert_subgraph_output_at`** (+ locked variants) — index-parameterized port insertion mirroring the removal path's shift/remap semantics, so port-removal undo restores port order.
- **`build_execution_plan`: exclude re-created ids from `removed_nodes`** — a node removed and re-created under the same id within one commit (project load = remove-all + rebuild) is alive; reporting it as removed desynchronized id-keyed consumer stores.

## Testing

- 116/116 crate tests (16 new, all TDD red→green).
- Consumed end-to-end by revion's op-log test suites (inverse-identity, round-trip, double-load).