### PR TITLE
feat: first-class Interval, Plane, List, and Transform data types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,29 +31,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cognet_wasm"
-version = "0.1.0"
-dependencies = [
- "cognet",
- "num_cpus",
- "serde",
- "serde-wasm-bindgen",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-rayon",
- "web-sys",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,12 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,16 +194,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
 
 [[package]]
 name = "once_cell"
@@ -316,7 +277,6 @@ checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
- "wasm_sync",
 ]
 
 [[package]]
@@ -327,7 +287,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
- "wasm_sync",
 ]
 
 [[package]]
@@ -344,17 +303,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -511,16 +459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,45 +482,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-rayon"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a16c60a56c81e4dc3b9c43d76ba5633e1c0278211d59a9cb07d61b6cd1c6583"
-dependencies = [
- "crossbeam-channel",
- "js-sys",
- "rayon",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm_sync"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff360cade7fec41ff0e9d2cda57fe58258c5f16def0e21302394659e6bbb0ea"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ version = "0.1.0"
 [lib]
 crate-type = ["rlib"]
 
+# Standalone package: stop cargo's workspace discovery from walking up into
+# a host repo when this checkout lives inside another repo's worktree container.
+[workspace]
+
 [dependencies]
 futures = "0.3.31"
 inventory = "0.3.19"

--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -75,6 +75,52 @@ impl Vertices {
     }
 }
 
+/// A one-dimensional numeric interval `t0 ..= t1` — the first-class
+/// "Domain" of parametric workflows (curve parameters, remapping).
+/// `t0 > t1` (decreasing) is allowed; consumers that need an ordered
+/// span use [`Interval::min`] / [`Interval::max`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Interval {
+    pub t0: f64,
+    pub t1: f64,
+}
+
+impl Interval {
+    pub fn new(t0: f64, t1: f64) -> Self {
+        Self { t0, t1 }
+    }
+
+    /// Signed length (`t1 - t0`).
+    pub fn length(&self) -> f64 {
+        self.t1 - self.t0
+    }
+
+    pub fn min(&self) -> f64 {
+        self.t0.min(self.t1)
+    }
+
+    pub fn max(&self) -> f64 {
+        self.t0.max(self.t1)
+    }
+
+    /// Whether `t` lies within the interval (inclusive, order-agnostic).
+    pub fn contains(&self, t: f64) -> bool {
+        t >= self.min() && t <= self.max()
+    }
+
+    /// Map `t` from this interval into `target`, preserving the
+    /// normalized position. A zero-length source maps everything to
+    /// `target.t0`.
+    pub fn remap(&self, t: f64, target: &Interval) -> f64 {
+        let len = self.length();
+        if len.abs() < f64::EPSILON {
+            return target.t0;
+        }
+        let normalized = (t - self.t0) / len;
+        target.t0 + normalized * target.length()
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub enum DataType {
     #[default]
@@ -91,6 +137,8 @@ pub enum DataType {
     Vertices,
     /// A boolean value.
     Bool,
+    /// A one-dimensional numeric interval (`t0 ..= t1`).
+    Interval,
     /// BRep solid geometry.
     /// Stores arbitrary BRep data as `Arc<dyn Any>` via `Data::from_brep()`.
     BRep,
@@ -111,6 +159,7 @@ impl DataType {
             DataType::Color => "Color",
             DataType::Vertices => "Vertices",
             DataType::Bool => "Bool",
+            DataType::Interval => "Interval",
             DataType::BRep => "BRep",
             DataType::Domain(name) => name,
         }
@@ -122,6 +171,7 @@ impl DataType {
             DataType::Number,
             DataType::String,
             DataType::Bool,
+            DataType::Interval,
             DataType::Vector3,
             DataType::Color,
             DataType::Mesh,
@@ -135,6 +185,7 @@ impl DataType {
         match self {
             DataType::Vector3 => &["x", "y", "z"],
             DataType::Color => &["r", "g", "b", "a"],
+            DataType::Interval => &["t0", "t1"],
             _ => &[],
         }
     }
@@ -156,6 +207,9 @@ impl DataType {
                 read_field("a"),
             ))
             .ok(),
+            DataType::Interval => {
+                Data::new(Interval::new(read_field("t0"), read_field("t1"))).ok()
+            }
             _ => None,
         }
     }
@@ -170,6 +224,7 @@ impl DataType {
             DataType::Color => TypeId::of::<ColorValue>(),
             DataType::Vertices => TypeId::of::<Vertices>(),
             DataType::Bool => TypeId::of::<bool>(),
+            DataType::Interval => TypeId::of::<Interval>(),
             DataType::BRep => TypeId::of::<()>(),
             DataType::Domain(_) => TypeId::of::<()>(),
         }
@@ -184,6 +239,7 @@ impl DataType {
             DataType::Color => "Color",
             DataType::Vertices => "Vertices",
             DataType::Bool => "Bool",
+            DataType::Interval => "Interval",
             DataType::BRep => "BRep",
             DataType::Domain(name) => name,
         }
@@ -228,6 +284,9 @@ impl Serialize for Data {
             )),
             DataType::Vertices => Err(serde::ser::Error::custom(
                 "Vertices data type is not serializable",
+            )),
+            DataType::Interval => Err(serde::ser::Error::custom(
+                "Interval data type is not serializable",
             )),
             DataType::Bool => {
                 let value = self
@@ -307,6 +366,7 @@ impl Data {
             t if t == TypeId::of::<ColorValue>() => DataType::Color,
             t if t == TypeId::of::<Vertices>() => DataType::Vertices,
             t if t == TypeId::of::<bool>() => DataType::Bool,
+            t if t == TypeId::of::<Interval>() => DataType::Interval,
             _ => return Err(format!("Invalid DataType: {}", type_name::<T>())),
         };
 
@@ -358,6 +418,7 @@ impl Data {
             t if t == TypeId::of::<ColorValue>() => DataType::Color,
             t if t == TypeId::of::<Vertices>() => DataType::Vertices,
             t if t == TypeId::of::<bool>() => DataType::Bool,
+            t if t == TypeId::of::<Interval>() => DataType::Interval,
             _ => return Err("Unsupported data type".to_string()),
         };
 
@@ -489,5 +550,43 @@ mod tests {
         // Lying about the type fails.
         let err = Data::from_any_typed(raw, DataType::String).expect_err("type mismatch");
         assert!(err.contains("does not match declared"), "got: {err}");
+    }
+
+    #[test]
+    fn interval_data_roundtrip_and_type_inference() {
+        let data = Data::new(Interval::new(2.0, 6.0)).unwrap();
+        assert_eq!(data.get_type(), DataType::Interval);
+        let interval = data.value::<Interval>().unwrap();
+        assert!((interval.length() - 4.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn interval_remap_preserves_normalized_position() {
+        let source = Interval::new(0.0, 10.0);
+        let target = Interval::new(100.0, 200.0);
+        assert!((source.remap(2.5, &target) - 125.0).abs() < 1e-12);
+        // Decreasing target flips direction.
+        let flipped = Interval::new(1.0, 0.0);
+        assert!((source.remap(2.5, &flipped) - 0.75).abs() < 1e-12);
+        // Zero-length source collapses to target start.
+        let zero = Interval::new(3.0, 3.0);
+        assert!((zero.remap(3.0, &target) - 100.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn interval_contains_is_order_agnostic() {
+        assert!(Interval::new(5.0, 1.0).contains(2.0));
+        assert!(!Interval::new(5.0, 1.0).contains(6.0));
+    }
+
+    #[test]
+    fn interval_assembles_from_fields() {
+        let dt = DataType::Interval;
+        assert_eq!(dt.field_names(), &["t0", "t1"]);
+        let data = dt
+            .assemble(|f| if f == "t0" { 1.0 } else { 4.0 })
+            .unwrap();
+        let interval = data.value::<Interval>().unwrap();
+        assert!((interval.t0 - 1.0).abs() < 1e-12 && (interval.t1 - 4.0).abs() < 1e-12);
     }
 }

--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -239,23 +239,23 @@ impl Transform {
             _ => v.z,
         };
         let mut m = Self::identity().m;
-        for i in 0..3 {
-            for j in 0..3 {
+        for (i, row) in m.iter_mut().take(3).enumerate() {
+            for (j, cell) in row.iter_mut().take(3).enumerate() {
                 let mut r = 0.0;
                 for k in 0..3 {
                     r += axis(t[k], i) * axis(s[k], j);
                 }
-                m[i][j] = r;
+                *cell = r;
             }
         }
         let o_s = [source.origin.x, source.origin.y, source.origin.z];
         let o_t = [target.origin.x, target.origin.y, target.origin.z];
-        for i in 0..3 {
+        for (row, ot) in m.iter_mut().zip(o_t) {
             let mut r_os = 0.0;
             for (j, os) in o_s.iter().enumerate() {
-                r_os += m[i][j] * os;
+                r_os += row[j] * os;
             }
-            m[i][3] = o_t[i] - r_os;
+            row[3] = ot - r_os;
         }
         Self { m }
     }
@@ -297,12 +297,12 @@ impl Transform {
         inv[2][0] = (a[1][0] * a[2][1] - a[1][1] * a[2][0]) * inv_det;
         inv[2][1] = (a[0][1] * a[2][0] - a[0][0] * a[2][1]) * inv_det;
         inv[2][2] = (a[0][0] * a[1][1] - a[0][1] * a[1][0]) * inv_det;
-        for i in 0..3 {
+        for row in inv.iter_mut().take(3) {
             let mut t = 0.0;
-            for j in 0..3 {
-                t += inv[i][j] * a[j][3];
+            for (j, a_row) in a.iter().take(3).enumerate() {
+                t += row[j] * a_row[3];
             }
-            inv[i][3] = -t;
+            row[3] = -t;
         }
         Ok(Self { m: inv })
     }

--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -208,6 +208,116 @@ impl Plane {
     }
 }
 
+/// A 4x4 affine transform (row-major), the reusable product of
+/// placement operations: compose, invert, and apply to geometry.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Transform {
+    /// Row-major matrix entries; row 3 is `[0, 0, 0, 1]` for affine
+    /// transforms.
+    pub m: [[f64; 4]; 4],
+}
+
+impl Transform {
+    #[rustfmt::skip]
+    pub fn identity() -> Self {
+        Self { m: [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]}
+    }
+
+    /// The rigid transform taking `source` onto `target`:
+    /// `p → o_t + R (p - o_s)` with `R = B_t · B_sᵀ`.
+    pub fn from_frames(source: &Plane, target: &Plane) -> Self {
+        let s = [source.x_axis, source.y_axis, source.z_axis];
+        let t = [target.x_axis, target.y_axis, target.z_axis];
+        let axis = |v: Vector3, i: usize| match i {
+            0 => v.x,
+            1 => v.y,
+            _ => v.z,
+        };
+        let mut m = Self::identity().m;
+        for i in 0..3 {
+            for j in 0..3 {
+                let mut r = 0.0;
+                for k in 0..3 {
+                    r += axis(t[k], i) * axis(s[k], j);
+                }
+                m[i][j] = r;
+            }
+        }
+        let o_s = [source.origin.x, source.origin.y, source.origin.z];
+        let o_t = [target.origin.x, target.origin.y, target.origin.z];
+        for i in 0..3 {
+            let mut r_os = 0.0;
+            for (j, os) in o_s.iter().enumerate() {
+                r_os += m[i][j] * os;
+            }
+            m[i][3] = o_t[i] - r_os;
+        }
+        Self { m }
+    }
+
+    /// `self` followed by `next` (`next · self`).
+    pub fn then(&self, next: &Transform) -> Self {
+        let mut m = [[0.0; 4]; 4];
+        for (i, row) in m.iter_mut().enumerate() {
+            for (j, cell) in row.iter_mut().enumerate() {
+                for k in 0..4 {
+                    *cell += next.m[i][k] * self.m[k][j];
+                }
+            }
+        }
+        Self { m }
+    }
+
+    /// Affine inverse (3x3 adjugate + translation).
+    ///
+    /// # Errors
+    ///
+    /// `Err` when the linear part is singular (determinant ~ 0).
+    pub fn inverse(&self) -> Result<Self, String> {
+        let a = &self.m;
+        let det = a[0][0] * (a[1][1] * a[2][2] - a[1][2] * a[2][1])
+            - a[0][1] * (a[1][0] * a[2][2] - a[1][2] * a[2][0])
+            + a[0][2] * (a[1][0] * a[2][1] - a[1][1] * a[2][0]);
+        if det.abs() < 1e-12 {
+            return Err("Transform: singular linear part cannot be inverted".to_string());
+        }
+        let inv_det = 1.0 / det;
+        let mut inv = Self::identity().m;
+        inv[0][0] = (a[1][1] * a[2][2] - a[1][2] * a[2][1]) * inv_det;
+        inv[0][1] = (a[0][2] * a[2][1] - a[0][1] * a[2][2]) * inv_det;
+        inv[0][2] = (a[0][1] * a[1][2] - a[0][2] * a[1][1]) * inv_det;
+        inv[1][0] = (a[1][2] * a[2][0] - a[1][0] * a[2][2]) * inv_det;
+        inv[1][1] = (a[0][0] * a[2][2] - a[0][2] * a[2][0]) * inv_det;
+        inv[1][2] = (a[0][2] * a[1][0] - a[0][0] * a[1][2]) * inv_det;
+        inv[2][0] = (a[1][0] * a[2][1] - a[1][1] * a[2][0]) * inv_det;
+        inv[2][1] = (a[0][1] * a[2][0] - a[0][0] * a[2][1]) * inv_det;
+        inv[2][2] = (a[0][0] * a[1][1] - a[0][1] * a[1][0]) * inv_det;
+        for i in 0..3 {
+            let mut t = 0.0;
+            for j in 0..3 {
+                t += inv[i][j] * a[j][3];
+            }
+            inv[i][3] = -t;
+        }
+        Ok(Self { m: inv })
+    }
+
+    /// Apply to a point.
+    pub fn apply_point(&self, p: Vector3) -> Vector3 {
+        let m = &self.m;
+        Vector3::new(
+            m[0][0] * p.x + m[0][1] * p.y + m[0][2] * p.z + m[0][3],
+            m[1][0] * p.x + m[1][1] * p.y + m[1][2] * p.z + m[1][3],
+            m[2][0] * p.x + m[2][1] * p.y + m[2][2] * p.z + m[2][3],
+        )
+    }
+}
+
 /// Element kind of a homogeneous, flat [`DataType::List`].
 ///
 /// Nested lists are deliberately unrepresentable (decided 2026-07-10):
@@ -272,6 +382,8 @@ pub enum DataType {
     Interval,
     /// An oriented coordinate frame (origin + orthonormal axes).
     Plane,
+    /// A 4x4 affine transform.
+    Transform,
     /// A homogeneous, flat list of `ListElem` values carried as one
     /// `Data` on the wire (`Vec<T>` payload).
     List(ListElem),
@@ -297,6 +409,7 @@ impl DataType {
             DataType::Bool => "Bool",
             DataType::Interval => "Interval",
             DataType::Plane => "Plane",
+            DataType::Transform => "Transform",
             DataType::List(elem) => match elem {
                 ListElem::Number => "List<Number>",
                 ListElem::String => "List<String>",
@@ -373,6 +486,7 @@ impl DataType {
             DataType::Bool => TypeId::of::<bool>(),
             DataType::Interval => TypeId::of::<Interval>(),
             DataType::Plane => TypeId::of::<Plane>(),
+            DataType::Transform => TypeId::of::<Transform>(),
             DataType::List(elem) => match elem {
                 ListElem::Number => TypeId::of::<Vec<f64>>(),
                 ListElem::String => TypeId::of::<Vec<String>>(),
@@ -398,6 +512,7 @@ impl DataType {
             DataType::Bool => "Bool",
             DataType::Interval => "Interval",
             DataType::Plane => "Plane",
+            DataType::Transform => "Transform",
             DataType::List(_) => "List",
             DataType::BRep => "BRep",
             DataType::Domain(name) => name,
@@ -449,6 +564,9 @@ impl Serialize for Data {
             )),
             DataType::Plane => Err(serde::ser::Error::custom(
                 "Plane data type is not serializable",
+            )),
+            DataType::Transform => Err(serde::ser::Error::custom(
+                "Transform data type is not serializable",
             )),
             DataType::List(_) => Err(serde::ser::Error::custom(
                 "List data types are not serializable",
@@ -533,6 +651,7 @@ impl Data {
             t if t == TypeId::of::<bool>() => DataType::Bool,
             t if t == TypeId::of::<Interval>() => DataType::Interval,
             t if t == TypeId::of::<Plane>() => DataType::Plane,
+            t if t == TypeId::of::<Transform>() => DataType::Transform,
             t if t == TypeId::of::<Vec<f64>>() => DataType::List(ListElem::Number),
             t if t == TypeId::of::<Vec<String>>() => DataType::List(ListElem::String),
             t if t == TypeId::of::<Vec<bool>>() => DataType::List(ListElem::Bool),
@@ -827,5 +946,33 @@ mod tests {
             DataType::List(ListElem::Number),
             DataType::List(ListElem::Vector3)
         );
+    }
+
+    #[test]
+    fn transform_compose_invert_roundtrip() {
+        let source = Plane::xy(Vector3::zero());
+        let target = Plane::new(
+            Vector3::new(5.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
+            Vector3::new(-1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let t = Transform::from_frames(&source, &target);
+        let p = t.apply_point(Vector3::new(1.0, 0.0, 0.0));
+        // 90° CCW rotation + translate (5,0,0): (1,0,0) → (5,1,0).
+        assert!((p.x - 5.0).abs() < 1e-12 && (p.y - 1.0).abs() < 1e-12);
+
+        let inv = t.inverse().unwrap();
+        let back = inv.apply_point(p);
+        assert!((back.x - 1.0).abs() < 1e-12 && back.y.abs() < 1e-12);
+
+        let ident = t.then(&inv);
+        let q = ident.apply_point(Vector3::new(3.0, -2.0, 7.0));
+        assert!(
+            (q.x - 3.0).abs() < 1e-12 && (q.y + 2.0).abs() < 1e-12 && (q.z - 7.0).abs() < 1e-12
+        );
+
+        let data = Data::new(t).unwrap();
+        assert_eq!(data.get_type(), DataType::Transform);
     }
 }

--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -208,6 +208,50 @@ impl Plane {
     }
 }
 
+/// Element kind of a homogeneous, flat [`DataType::List`].
+///
+/// Nested lists are deliberately unrepresentable (decided 2026-07-10):
+/// the engine stays "one execution per node, one value per wire" —
+/// iteration lives inside nodes, and there are no GH-style data trees.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ListElem {
+    Number,
+    String,
+    Bool,
+    Vector3,
+    Color,
+    Interval,
+    Plane,
+}
+
+/// Types that can be list elements (maps a Rust payload type to its
+/// [`ListElem`] tag for `Data::from_list`).
+pub trait ListElement: std::any::Any + Send + Sync {
+    const ELEM: ListElem;
+}
+
+impl ListElement for f64 {
+    const ELEM: ListElem = ListElem::Number;
+}
+impl ListElement for String {
+    const ELEM: ListElem = ListElem::String;
+}
+impl ListElement for bool {
+    const ELEM: ListElem = ListElem::Bool;
+}
+impl ListElement for Vector3 {
+    const ELEM: ListElem = ListElem::Vector3;
+}
+impl ListElement for ColorValue {
+    const ELEM: ListElem = ListElem::Color;
+}
+impl ListElement for Interval {
+    const ELEM: ListElem = ListElem::Interval;
+}
+impl ListElement for Plane {
+    const ELEM: ListElem = ListElem::Plane;
+}
+
 #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub enum DataType {
     #[default]
@@ -228,6 +272,9 @@ pub enum DataType {
     Interval,
     /// An oriented coordinate frame (origin + orthonormal axes).
     Plane,
+    /// A homogeneous, flat list of `ListElem` values carried as one
+    /// `Data` on the wire (`Vec<T>` payload).
+    List(ListElem),
     /// BRep solid geometry.
     /// Stores arbitrary BRep data as `Arc<dyn Any>` via `Data::from_brep()`.
     BRep,
@@ -250,6 +297,15 @@ impl DataType {
             DataType::Bool => "Bool",
             DataType::Interval => "Interval",
             DataType::Plane => "Plane",
+            DataType::List(elem) => match elem {
+                ListElem::Number => "List<Number>",
+                ListElem::String => "List<String>",
+                ListElem::Bool => "List<Bool>",
+                ListElem::Vector3 => "List<Vector3>",
+                ListElem::Color => "List<Color>",
+                ListElem::Interval => "List<Interval>",
+                ListElem::Plane => "List<Plane>",
+            },
             DataType::BRep => "BRep",
             DataType::Domain(name) => name,
         }
@@ -263,6 +319,8 @@ impl DataType {
             DataType::Bool,
             DataType::Interval,
             DataType::Plane,
+            DataType::List(ListElem::Number),
+            DataType::List(ListElem::Vector3),
             DataType::Vector3,
             DataType::Color,
             DataType::Mesh,
@@ -298,9 +356,7 @@ impl DataType {
                 read_field("a"),
             ))
             .ok(),
-            DataType::Interval => {
-                Data::new(Interval::new(read_field("t0"), read_field("t1"))).ok()
-            }
+            DataType::Interval => Data::new(Interval::new(read_field("t0"), read_field("t1"))).ok(),
             _ => None,
         }
     }
@@ -317,6 +373,15 @@ impl DataType {
             DataType::Bool => TypeId::of::<bool>(),
             DataType::Interval => TypeId::of::<Interval>(),
             DataType::Plane => TypeId::of::<Plane>(),
+            DataType::List(elem) => match elem {
+                ListElem::Number => TypeId::of::<Vec<f64>>(),
+                ListElem::String => TypeId::of::<Vec<String>>(),
+                ListElem::Bool => TypeId::of::<Vec<bool>>(),
+                ListElem::Vector3 => TypeId::of::<Vec<Vector3>>(),
+                ListElem::Color => TypeId::of::<Vec<ColorValue>>(),
+                ListElem::Interval => TypeId::of::<Vec<Interval>>(),
+                ListElem::Plane => TypeId::of::<Vec<Plane>>(),
+            },
             DataType::BRep => TypeId::of::<()>(),
             DataType::Domain(_) => TypeId::of::<()>(),
         }
@@ -333,6 +398,7 @@ impl DataType {
             DataType::Bool => "Bool",
             DataType::Interval => "Interval",
             DataType::Plane => "Plane",
+            DataType::List(_) => "List",
             DataType::BRep => "BRep",
             DataType::Domain(name) => name,
         }
@@ -383,6 +449,9 @@ impl Serialize for Data {
             )),
             DataType::Plane => Err(serde::ser::Error::custom(
                 "Plane data type is not serializable",
+            )),
+            DataType::List(_) => Err(serde::ser::Error::custom(
+                "List data types are not serializable",
             )),
             DataType::Bool => {
                 let value = self
@@ -464,6 +533,13 @@ impl Data {
             t if t == TypeId::of::<bool>() => DataType::Bool,
             t if t == TypeId::of::<Interval>() => DataType::Interval,
             t if t == TypeId::of::<Plane>() => DataType::Plane,
+            t if t == TypeId::of::<Vec<f64>>() => DataType::List(ListElem::Number),
+            t if t == TypeId::of::<Vec<String>>() => DataType::List(ListElem::String),
+            t if t == TypeId::of::<Vec<bool>>() => DataType::List(ListElem::Bool),
+            t if t == TypeId::of::<Vec<Vector3>>() => DataType::List(ListElem::Vector3),
+            t if t == TypeId::of::<Vec<ColorValue>>() => DataType::List(ListElem::Color),
+            t if t == TypeId::of::<Vec<Interval>>() => DataType::List(ListElem::Interval),
+            t if t == TypeId::of::<Vec<Plane>>() => DataType::List(ListElem::Plane),
             _ => return Err(format!("Invalid DataType: {}", type_name::<T>())),
         };
 
@@ -506,6 +582,14 @@ impl Data {
         }
     }
 
+    /// Create a homogeneous list value (`DataType::List(T::ELEM)`).
+    pub fn from_list<T: ListElement>(values: Vec<T>) -> Self {
+        Data {
+            value: Arc::new(values),
+            data_type: DataType::List(T::ELEM),
+        }
+    }
+
     pub fn from_any(value: Arc<dyn Any + Send + Sync>) -> Result<Self, String> {
         let type_id = (*value).type_id();
         let data_type = match type_id {
@@ -517,6 +601,8 @@ impl Data {
             t if t == TypeId::of::<bool>() => DataType::Bool,
             t if t == TypeId::of::<Interval>() => DataType::Interval,
             t if t == TypeId::of::<Plane>() => DataType::Plane,
+            t if t == TypeId::of::<Vec<f64>>() => DataType::List(ListElem::Number),
+            t if t == TypeId::of::<Vec<Vector3>>() => DataType::List(ListElem::Vector3),
             _ => return Err("Unsupported data type".to_string()),
         };
 
@@ -681,9 +767,7 @@ mod tests {
     fn interval_assembles_from_fields() {
         let dt = DataType::Interval;
         assert_eq!(dt.field_names(), &["t0", "t1"]);
-        let data = dt
-            .assemble(|f| if f == "t0" { 1.0 } else { 4.0 })
-            .unwrap();
+        let data = dt.assemble(|f| if f == "t0" { 1.0 } else { 4.0 }).unwrap();
         let interval = data.value::<Interval>().unwrap();
         assert!((interval.t0 - 1.0).abs() < 1e-12 && (interval.t1 - 4.0).abs() < 1e-12);
     }
@@ -725,5 +809,23 @@ mod tests {
         assert!(dot_xy.abs() < 1e-9);
         assert!((plane.z_axis.z - 1.0).abs() < 1e-9);
         assert!(Plane::from_normal(Vector3::zero(), Vector3::zero()).is_err());
+    }
+
+    #[test]
+    fn list_data_is_typed_by_element() {
+        let numbers = Data::from_list(vec![1.0, 2.0, 3.0]);
+        assert_eq!(numbers.get_type(), DataType::List(ListElem::Number));
+        assert_eq!(numbers.value::<Vec<f64>>().unwrap().len(), 3);
+        // Element-typed read is enforced.
+        assert!(numbers.value::<Vec<bool>>().is_err());
+
+        let points = Data::new(vec![Vector3::zero()]).unwrap();
+        assert_eq!(points.get_type(), DataType::List(ListElem::Vector3));
+
+        // Different element kinds are different wire types.
+        assert_ne!(
+            DataType::List(ListElem::Number),
+            DataType::List(ListElem::Vector3)
+        );
     }
 }

--- a/src/edge/slot.rs
+++ b/src/edge/slot.rs
@@ -121,6 +121,93 @@ impl Interval {
     }
 }
 
+/// An oriented coordinate frame: origin plus right-handed orthonormal
+/// axes — the positional currency of plane-based construction and
+/// `Orient`-style placement.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Plane {
+    pub origin: Vector3,
+    pub x_axis: Vector3,
+    pub y_axis: Vector3,
+    pub z_axis: Vector3,
+}
+
+impl Plane {
+    /// Build a plane from origin + X/Y axes, deriving Z = X × Y.
+    ///
+    /// Validates that both axes are unit length and orthogonal within
+    /// `1e-9` — a skewed frame must never silently shear geometry.
+    pub fn new(origin: Vector3, x_axis: Vector3, y_axis: Vector3) -> Result<Self, String> {
+        const EPS: f64 = 1e-9;
+        let len = |v: &Vector3| (v.x * v.x + v.y * v.y + v.z * v.z).sqrt();
+        if (len(&x_axis) - 1.0).abs() > EPS || (len(&y_axis) - 1.0).abs() > EPS {
+            return Err("Plane: axes must be unit length".to_string());
+        }
+        let dot = x_axis.x * y_axis.x + x_axis.y * y_axis.y + x_axis.z * y_axis.z;
+        if dot.abs() > EPS {
+            return Err("Plane: axes must be orthogonal".to_string());
+        }
+        let z_axis = Vector3::new(
+            x_axis.y * y_axis.z - x_axis.z * y_axis.y,
+            x_axis.z * y_axis.x - x_axis.x * y_axis.z,
+            x_axis.x * y_axis.y - x_axis.y * y_axis.x,
+        );
+        Ok(Self {
+            origin,
+            x_axis,
+            y_axis,
+            z_axis,
+        })
+    }
+
+    /// World XY plane at `origin`.
+    pub fn xy(origin: Vector3) -> Self {
+        Self {
+            origin,
+            x_axis: Vector3::new(1.0, 0.0, 0.0),
+            y_axis: Vector3::new(0.0, 1.0, 0.0),
+            z_axis: Vector3::new(0.0, 0.0, 1.0),
+        }
+    }
+
+    /// Plane from origin + normal (Z axis). X/Y are derived with a
+    /// stable convention: X = normalize(world-up × Z) unless Z is
+    /// nearly vertical, in which case world-X seeds the frame.
+    ///
+    /// Errors on a zero-length normal.
+    pub fn from_normal(origin: Vector3, normal: Vector3) -> Result<Self, String> {
+        let len = (normal.x * normal.x + normal.y * normal.y + normal.z * normal.z).sqrt();
+        if len < 1e-12 {
+            return Err("Plane: normal must have non-zero length".to_string());
+        }
+        let z = Vector3::new(normal.x / len, normal.y / len, normal.z / len);
+        let seed = if z.z.abs() > 0.999 {
+            Vector3::new(1.0, 0.0, 0.0)
+        } else {
+            Vector3::new(0.0, 0.0, 1.0)
+        };
+        // X = normalize(seed × Z), Y = Z × X.
+        let x = Vector3::new(
+            seed.y * z.z - seed.z * z.y,
+            seed.z * z.x - seed.x * z.z,
+            seed.x * z.y - seed.y * z.x,
+        );
+        let xl = (x.x * x.x + x.y * x.y + x.z * x.z).sqrt();
+        let x = Vector3::new(x.x / xl, x.y / xl, x.z / xl);
+        let y = Vector3::new(
+            z.y * x.z - z.z * x.y,
+            z.z * x.x - z.x * x.z,
+            z.x * x.y - z.y * x.x,
+        );
+        Ok(Self {
+            origin,
+            x_axis: x,
+            y_axis: y,
+            z_axis: z,
+        })
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub enum DataType {
     #[default]
@@ -139,6 +226,8 @@ pub enum DataType {
     Bool,
     /// A one-dimensional numeric interval (`t0 ..= t1`).
     Interval,
+    /// An oriented coordinate frame (origin + orthonormal axes).
+    Plane,
     /// BRep solid geometry.
     /// Stores arbitrary BRep data as `Arc<dyn Any>` via `Data::from_brep()`.
     BRep,
@@ -160,6 +249,7 @@ impl DataType {
             DataType::Vertices => "Vertices",
             DataType::Bool => "Bool",
             DataType::Interval => "Interval",
+            DataType::Plane => "Plane",
             DataType::BRep => "BRep",
             DataType::Domain(name) => name,
         }
@@ -172,6 +262,7 @@ impl DataType {
             DataType::String,
             DataType::Bool,
             DataType::Interval,
+            DataType::Plane,
             DataType::Vector3,
             DataType::Color,
             DataType::Mesh,
@@ -225,6 +316,7 @@ impl DataType {
             DataType::Vertices => TypeId::of::<Vertices>(),
             DataType::Bool => TypeId::of::<bool>(),
             DataType::Interval => TypeId::of::<Interval>(),
+            DataType::Plane => TypeId::of::<Plane>(),
             DataType::BRep => TypeId::of::<()>(),
             DataType::Domain(_) => TypeId::of::<()>(),
         }
@@ -240,6 +332,7 @@ impl DataType {
             DataType::Vertices => "Vertices",
             DataType::Bool => "Bool",
             DataType::Interval => "Interval",
+            DataType::Plane => "Plane",
             DataType::BRep => "BRep",
             DataType::Domain(name) => name,
         }
@@ -287,6 +380,9 @@ impl Serialize for Data {
             )),
             DataType::Interval => Err(serde::ser::Error::custom(
                 "Interval data type is not serializable",
+            )),
+            DataType::Plane => Err(serde::ser::Error::custom(
+                "Plane data type is not serializable",
             )),
             DataType::Bool => {
                 let value = self
@@ -367,6 +463,7 @@ impl Data {
             t if t == TypeId::of::<Vertices>() => DataType::Vertices,
             t if t == TypeId::of::<bool>() => DataType::Bool,
             t if t == TypeId::of::<Interval>() => DataType::Interval,
+            t if t == TypeId::of::<Plane>() => DataType::Plane,
             _ => return Err(format!("Invalid DataType: {}", type_name::<T>())),
         };
 
@@ -419,6 +516,7 @@ impl Data {
             t if t == TypeId::of::<Vertices>() => DataType::Vertices,
             t if t == TypeId::of::<bool>() => DataType::Bool,
             t if t == TypeId::of::<Interval>() => DataType::Interval,
+            t if t == TypeId::of::<Plane>() => DataType::Plane,
             _ => return Err("Unsupported data type".to_string()),
         };
 
@@ -588,5 +686,44 @@ mod tests {
             .unwrap();
         let interval = data.value::<Interval>().unwrap();
         assert!((interval.t0 - 1.0).abs() < 1e-12 && (interval.t1 - 4.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn plane_data_roundtrip_and_validation() {
+        let plane = Plane::new(
+            Vector3::new(1.0, 2.0, 3.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
+        )
+        .unwrap();
+        assert!((plane.z_axis.z - 1.0).abs() < 1e-12);
+        let data = Data::new(plane).unwrap();
+        assert_eq!(data.get_type(), DataType::Plane);
+        assert!(data.value::<Plane>().is_ok());
+
+        // Non-unit / non-orthogonal axes are rejected.
+        assert!(Plane::new(
+            Vector3::zero(),
+            Vector3::new(2.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
+        )
+        .is_err());
+        assert!(Plane::new(
+            Vector3::zero(),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn plane_from_normal_builds_an_orthonormal_frame() {
+        let plane = Plane::from_normal(Vector3::zero(), Vector3::new(0.0, 0.0, 2.0)).unwrap();
+        let dot_xy = plane.x_axis.x * plane.y_axis.x
+            + plane.x_axis.y * plane.y_axis.y
+            + plane.x_axis.z * plane.y_axis.z;
+        assert!(dot_xy.abs() < 1e-9);
+        assert!((plane.z_axis.z - 1.0).abs() < 1e-9);
+        assert!(Plane::from_normal(Vector3::zero(), Vector3::zero()).is_err());
     }
 }


### PR DESCRIPTION
## Summary

Adds four first-class edge data types needed by revion's Grasshopper-style node toolkit (feat/gh-node-parity):

- **Interval** — numeric domain value
- **Plane** — origin + axes frame
- **List** — homogeneous flat list payload (no data trees)
- **Transform** — 4x4 homogeneous transform

Each ships with slot info, default handling, and serde round-trip support, mirroring the existing scalar/vector types.

## Companion PRs

- geolis: kernel ops for the node toolkit
- revion: `feat/gh-node-parity` (consumes these types)