### PR TITLE
feat: add the Bool Output sink node

### DIFF
--- a/src/node/outputs/bool_output.rs
+++ b/src/node/outputs/bool_output.rs
@@ -1,0 +1,27 @@
+use crate::{
+    register_nodes, DataType, ExecutionContext, NodeCategory, NodeImpl, NodeMeta, SlotDef,
+};
+
+#[derive(Debug)]
+pub struct BoolOutput;
+
+impl NodeMeta for BoolOutput {
+    const NAME: &'static str = "Bool Output";
+    const CATEGORY: NodeCategory = NodeCategory::Output;
+    const INPUTS: &'static [SlotDef] = &[SlotDef {
+        label: "Value",
+        data_type: DataType::Bool,
+        max_connections: Some(1),
+        inspector_visible: true,
+    }];
+    const OUTPUTS: &'static [SlotDef] = &[];
+}
+
+impl NodeImpl for BoolOutput {
+    fn execute_sync(&self, _ctx: ExecutionContext) -> Result<(), String> {
+        // Output node just reads its input - the value is read from cache for UI display
+        Ok(())
+    }
+}
+
+register_nodes!(BoolOutput);

--- a/src/node/outputs/mod.rs
+++ b/src/node/outputs/mod.rs
@@ -1,5 +1,7 @@
+pub mod bool_output;
 pub mod number_output;
 pub mod string_output;
 
+pub use bool_output::*;
 pub use number_output::*;
 pub use string_output::*;


### PR DESCRIPTION
## Summary

Adds a Bool Output sink node mirroring the existing Number Output / String Output sinks, so boolean results (e.g. a simulation's pass/fail output) can be displayed on the graph. Required by revion's simulation v2 branch.

## Changes

- New Bool Output node: one Bool input, zero output slots, no-op execute
- The executor's existing zero-output capture path publishes the input value for UI display, identical to the Number/String sinks