### PR TITLE
fix(graph): deterministic subgraph edge order + operator list broadcast

### DIFF
--- a/src/node/operators/add.rs
+++ b/src/node/operators/add.rs
@@ -1,5 +1,11 @@
+//! Add operator node.
+//!
+//! Adds two numbers (A + B). Every operand carries a scalar port and a `List(Number)`
+//! alternative; see [`super::broadcast`] for the elementwise semantics.
+
 use crate::{
-    register_nodes, Data, DataType, ExecutionContext, NodeCategory, NodeImpl, NodeMeta, SlotDef,
+    node::operators::broadcast, register_nodes, ExecutionContext, NodeCategory, NodeImpl, NodeMeta,
+    SlotDef,
 };
 
 /// Adds two numbers (A + B)
@@ -10,45 +16,20 @@ impl NodeMeta for AddNode {
     const NAME: &'static str = "Add";
     const CATEGORY: NodeCategory = NodeCategory::Math;
     const INPUTS: &'static [SlotDef] = &[
-        SlotDef {
-            label: "A",
-            data_type: DataType::Number,
-            max_connections: Some(1),
-            inspector_visible: true,
-        },
-        SlotDef {
-            label: "B",
-            data_type: DataType::Number,
-            max_connections: Some(1),
-            inspector_visible: true,
-        },
+        broadcast::number_operand("A"),
+        broadcast::number_operand("B"),
+        broadcast::list_operand("A[]"),
+        broadcast::list_operand("B[]"),
     ];
-    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
-        label: "Sum",
-        data_type: DataType::Number,
-        max_connections: None,
-        inspector_visible: true,
-    }];
+    const OUTPUTS: &'static [SlotDef] = &[
+        broadcast::number_result("Sum"),
+        broadcast::list_result("Sums"),
+    ];
 }
 
 impl NodeImpl for AddNode {
     fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
-        let a: f64 = ctx
-            .input_values
-            .first()
-            .and_then(|v| v.first())
-            .and_then(|d| d.value::<f64>().ok().copied())
-            .unwrap_or(0.0);
-
-        let b: f64 = ctx
-            .input_values
-            .get(1)
-            .and_then(|v| v.first())
-            .and_then(|d| d.value::<f64>().ok().copied())
-            .unwrap_or(0.0);
-
-        ctx.output_writer.set(0, Data::new(a + b)?)?;
-        Ok(())
+        broadcast::apply(&ctx, Self::NAME, |a, b| a + b)
     }
 }
 

--- a/src/node/operators/broadcast.rs
+++ b/src/node/operators/broadcast.rs
@@ -1,0 +1,341 @@
+//! Elementwise list broadcast shared by the binary arithmetic operators.
+//!
+//! Each operator carries two forms of every operand: the scalar port and a
+//! typed `List(Number)` alternative. Slot types are compared exactly, so a
+//! list cannot be an overload of the scalar port — it has to be its own
+//! slot, the same alternative-source shape used wherever a node accepts
+//! one payload in two shapes. A wired `A[]` decides `A`; otherwise the
+//! scalar `A` does.
+//!
+//! When at least one operand arrives as a list the operation is applied
+//! once per element — scalars broadcast, and every list operand must share
+//! the same length. The per-element results go to the list output; the
+//! scalar output stays unwritten, and vice versa, so a consumer always
+//! reads the shape it asked for.
+//!
+//! Iteration lives inside the node. The engine never auto-loops: one
+//! execution per node, one value per wire.
+
+use crate::{Data, DataType, ExecutionContext, ListElem, SlotDef};
+
+/// Slot index of the per-element form of operand `A`; `B[]` follows it.
+const LIST_SLOT_BASE: usize = 2;
+
+/// The scalar form of one operand.
+pub(crate) const fn number_operand(label: &'static str) -> SlotDef {
+    SlotDef {
+        label,
+        data_type: DataType::Number,
+        max_connections: Some(1),
+        inspector_visible: true,
+    }
+}
+
+/// The per-element form of one operand.
+pub(crate) const fn list_operand(label: &'static str) -> SlotDef {
+    SlotDef {
+        label,
+        data_type: DataType::List(ListElem::Number),
+        max_connections: Some(1),
+        inspector_visible: false,
+    }
+}
+
+/// The scalar result.
+pub(crate) const fn number_result(label: &'static str) -> SlotDef {
+    SlotDef {
+        label,
+        data_type: DataType::Number,
+        max_connections: None,
+        inspector_visible: true,
+    }
+}
+
+/// The per-element result.
+pub(crate) const fn list_result(label: &'static str) -> SlotDef {
+    SlotDef {
+        label,
+        data_type: DataType::List(ListElem::Number),
+        max_connections: None,
+        inspector_visible: true,
+    }
+}
+
+/// One operand as connected: a scalar that broadcasts, or a list that maps.
+enum Operand {
+    Scalar(f64),
+    List(Vec<f64>),
+}
+
+/// Reads operand `index`, preferring its per-element slot over its scalar
+/// one. An unwired scalar reads as `0.0`, matching the operators' own
+/// long-standing default.
+fn read_operand(ctx: &ExecutionContext, index: usize) -> Operand {
+    ctx.input_values
+        .get(LIST_SLOT_BASE + index)
+        .and_then(|values| values.first())
+        .and_then(|data| data.value::<Vec<f64>>().ok().cloned())
+        .map_or_else(
+            || {
+                Operand::Scalar(
+                    ctx.input_values
+                        .get(index)
+                        .and_then(|v| v.first())
+                        .and_then(|d| d.value::<f64>().ok().copied())
+                        .unwrap_or(0.0),
+                )
+            },
+            Operand::List,
+        )
+}
+
+/// Applies `op` over the node's two operands, writing the scalar result to
+/// slot 0 or the per-element results to slot 1 depending on how the
+/// operands arrived.
+pub(crate) fn apply(
+    ctx: &ExecutionContext,
+    node: &str,
+    op: fn(f64, f64) -> f64,
+) -> Result<(), String> {
+    let operands = [read_operand(ctx, 0), read_operand(ctx, 1)];
+
+    let length = operands.iter().find_map(|operand| match operand {
+        Operand::List(values) => Some(values.len()),
+        Operand::Scalar(_) => None,
+    });
+    let Some(length) = length else {
+        let scalars = [&operands[0], &operands[1]].map(|operand| match operand {
+            Operand::Scalar(value) => *value,
+            Operand::List(_) => unreachable!("no list operand in scalar mode"),
+        });
+        return ctx
+            .output_writer
+            .set(0, Data::new(op(scalars[0], scalars[1]))?);
+    };
+
+    for (index, operand) in operands.iter().enumerate() {
+        if let Operand::List(values) = operand {
+            if values.len() != length {
+                let label = if index == 0 { "A[]" } else { "B[]" };
+                return Err(format!(
+                    "{node}: list inputs must share one length; '{label}' has {} elements, \
+                     expected {length}",
+                    values.len()
+                ));
+            }
+        }
+    }
+
+    let results = (0..length)
+        .map(|k| {
+            let scalars = [&operands[0], &operands[1]].map(|operand| match operand {
+                Operand::Scalar(value) => *value,
+                Operand::List(values) => values[k],
+            });
+            op(scalars[0], scalars[1])
+        })
+        .collect::<Vec<f64>>();
+    ctx.output_writer.set(1, Data::from_list(results))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        AddNode, DivideNode, ExecutionCache, MultiplyNode, NodeId, NodeImpl, NodeMeta, NodePath,
+        OutputSlotId, OutputWriter, SharedExecutionCache, SubtractNode,
+    };
+
+    /// Runs a node over raw slot vectors and returns the writer's cache
+    /// alongside the scalar and list output slot ids, so a test can assert
+    /// which of the two the node actually wrote.
+    fn run(
+        node: &dyn NodeImpl,
+        inputs: Vec<Vec<Data>>,
+    ) -> Result<(SharedExecutionCache, OutputSlotId, OutputSlotId), String> {
+        let cache = SharedExecutionCache::new(ExecutionCache::default());
+        let scalar = OutputSlotId::new();
+        let list = OutputSlotId::new();
+        let writer = OutputWriter::new(
+            cache.share(),
+            vec![
+                (scalar, DataType::Number),
+                (list, DataType::List(ListElem::Number)),
+            ],
+        );
+        let ctx = ExecutionContext {
+            path: NodePath::root().child(NodeId::new()),
+            node_data: None,
+            input_values: inputs,
+            output_writer: writer,
+        };
+        node.execute_sync(ctx)?;
+        Ok((cache, scalar, list))
+    }
+
+    fn num(value: f64) -> Vec<Data> {
+        vec![Data::new(value).expect("number")]
+    }
+
+    fn list(values: &[f64]) -> Vec<Data> {
+        vec![Data::from_list(values.to_vec())]
+    }
+
+    fn scalar_out(cache: &SharedExecutionCache, slot: &OutputSlotId) -> Option<f64> {
+        cache
+            .read()
+            .expect("read")
+            .get_output(slot)
+            .and_then(|data| data.value::<f64>().ok().copied())
+    }
+
+    fn list_out(cache: &SharedExecutionCache, slot: &OutputSlotId) -> Option<Vec<f64>> {
+        cache
+            .read()
+            .expect("read")
+            .get_output(slot)
+            .and_then(|data| data.value::<Vec<f64>>().ok().cloned())
+    }
+
+    /// With no list wired, the operators behave exactly as they always
+    /// have: scalar slot written, list slot untouched.
+    #[test]
+    fn scalar_mode_writes_only_the_scalar_output() {
+        let (cache, scalar, list_slot) =
+            run(&AddNode, vec![num(2.0), num(3.0)]).expect("add executes");
+        assert_eq!(scalar_out(&cache, &scalar), Some(5.0));
+        assert_eq!(
+            list_out(&cache, &list_slot),
+            None,
+            "the list output must stay unwritten in scalar mode",
+        );
+    }
+
+    /// A wired per-element slot decides the operand, and the results leave
+    /// on the list output — the scalar one stays unwritten so a consumer
+    /// never silently reads one element of a mapped operation.
+    #[test]
+    fn a_wired_list_operand_maps_elementwise() {
+        let (cache, scalar, list_slot) = run(
+            &AddNode,
+            vec![Vec::new(), num(10.0), list(&[1.0, 2.0, 3.0]), Vec::new()],
+        )
+        .expect("add executes");
+        assert_eq!(list_out(&cache, &list_slot), Some(vec![11.0, 12.0, 13.0]));
+        assert_eq!(
+            scalar_out(&cache, &scalar),
+            None,
+            "the scalar output must stay unwritten in list mode",
+        );
+    }
+
+    #[test]
+    fn two_lists_of_equal_length_pair_up() {
+        let (cache, _scalar, list_slot) = run(
+            &SubtractNode,
+            vec![
+                Vec::new(),
+                Vec::new(),
+                list(&[10.0, 20.0]),
+                list(&[1.0, 2.0]),
+            ],
+        )
+        .expect("subtract executes");
+        assert_eq!(list_out(&cache, &list_slot), Some(vec![9.0, 18.0]));
+    }
+
+    #[test]
+    fn a_length_mismatch_is_a_typed_error() {
+        let Err(err) = run(
+            &MultiplyNode,
+            vec![
+                Vec::new(),
+                Vec::new(),
+                list(&[1.0, 2.0]),
+                list(&[3.0, 4.0, 5.0]),
+            ],
+        ) else {
+            panic!("mismatched lengths must error");
+        };
+        assert!(err.contains("must share one length"), "got: {err}");
+        assert!(err.contains("'B[]' has 3 elements"), "got: {err}");
+    }
+
+    /// The scalar port is the fallback, not an override: wiring both leaves
+    /// the list in charge, the same precedence every alternative-source
+    /// slot uses.
+    #[test]
+    fn the_list_slot_wins_over_the_scalar_slot() {
+        let (cache, _scalar, list_slot) = run(
+            &AddNode,
+            vec![num(100.0), num(1.0), list(&[1.0, 2.0]), Vec::new()],
+        )
+        .expect("add executes");
+        assert_eq!(list_out(&cache, &list_slot), Some(vec![2.0, 3.0]));
+    }
+
+    /// An empty list maps to an empty list — no elements, no error.
+    #[test]
+    fn an_empty_list_maps_to_an_empty_list() {
+        let (cache, _scalar, list_slot) =
+            run(&AddNode, vec![Vec::new(), num(1.0), list(&[]), Vec::new()]).expect("add executes");
+        assert_eq!(list_out(&cache, &list_slot), Some(Vec::new()));
+    }
+
+    /// `Divide`'s zero-divisor substitution has to apply per element too,
+    /// or the scalar and list forms of one node would disagree.
+    #[test]
+    fn divide_substitutes_zero_per_element_as_it_does_for_a_scalar() {
+        let (cache, scalar, _list) =
+            run(&DivideNode, vec![num(6.0), num(0.0)]).expect("divide executes");
+        assert_eq!(scalar_out(&cache, &scalar), Some(0.0));
+
+        let (cache, _scalar, list_slot) = run(
+            &DivideNode,
+            vec![Vec::new(), Vec::new(), list(&[6.0, 8.0]), list(&[0.0, 2.0])],
+        )
+        .expect("divide executes");
+        assert_eq!(list_out(&cache, &list_slot), Some(vec![0.0, 4.0]));
+    }
+
+    /// Every operator declares both forms of both operands, so the slot
+    /// layout the helper assumes is the layout each node publishes.
+    #[test]
+    fn every_operator_declares_both_forms_of_both_operands() {
+        for (inputs, outputs, name) in [
+            (AddNode::INPUTS, AddNode::OUTPUTS, AddNode::NAME),
+            (
+                SubtractNode::INPUTS,
+                SubtractNode::OUTPUTS,
+                SubtractNode::NAME,
+            ),
+            (
+                MultiplyNode::INPUTS,
+                MultiplyNode::OUTPUTS,
+                MultiplyNode::NAME,
+            ),
+            (DivideNode::INPUTS, DivideNode::OUTPUTS, DivideNode::NAME),
+        ] {
+            assert_eq!(inputs.len(), 4, "{name} inputs");
+            assert_eq!(inputs[0].data_type, DataType::Number, "{name} A");
+            assert_eq!(inputs[1].data_type, DataType::Number, "{name} B");
+            assert_eq!(
+                inputs[LIST_SLOT_BASE].data_type,
+                DataType::List(ListElem::Number),
+                "{name} A[]",
+            );
+            assert_eq!(
+                inputs[LIST_SLOT_BASE + 1].data_type,
+                DataType::List(ListElem::Number),
+                "{name} B[]",
+            );
+            assert_eq!(outputs.len(), 2, "{name} outputs");
+            assert_eq!(outputs[0].data_type, DataType::Number, "{name} scalar out");
+            assert_eq!(
+                outputs[1].data_type,
+                DataType::List(ListElem::Number),
+                "{name} list out",
+            );
+        }
+    }
+}

--- a/src/node/operators/divide.rs
+++ b/src/node/operators/divide.rs
@@ -1,9 +1,14 @@
 //! Divide operator node.
 //!
-//! Divides A by B. Returns 0.0 when B is zero.
+//! Divides A by B. Returns 0.0 when B is zero — the same substitution
+//! applies per element in list mode, so the scalar and per-element forms of
+//! one node never disagree. Every operand carries a scalar port and a
+//! `List(Number)` alternative; see [`super::broadcast`] for the elementwise
+//! semantics.
 
 use crate::{
-    register_nodes, Data, DataType, ExecutionContext, NodeCategory, NodeImpl, NodeMeta, SlotDef,
+    node::operators::broadcast, register_nodes, ExecutionContext, NodeCategory, NodeImpl, NodeMeta,
+    SlotDef,
 };
 
 /// Divides A by B (A / B)
@@ -14,46 +19,20 @@ impl NodeMeta for DivideNode {
     const NAME: &'static str = "Divide";
     const CATEGORY: NodeCategory = NodeCategory::Math;
     const INPUTS: &'static [SlotDef] = &[
-        SlotDef {
-            label: "A",
-            data_type: DataType::Number,
-            max_connections: Some(1),
-            inspector_visible: true,
-        },
-        SlotDef {
-            label: "B",
-            data_type: DataType::Number,
-            max_connections: Some(1),
-            inspector_visible: true,
-        },
+        broadcast::number_operand("A"),
+        broadcast::number_operand("B"),
+        broadcast::list_operand("A[]"),
+        broadcast::list_operand("B[]"),
     ];
-    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
-        label: "Quotient",
-        data_type: DataType::Number,
-        max_connections: None,
-        inspector_visible: true,
-    }];
+    const OUTPUTS: &'static [SlotDef] = &[
+        broadcast::number_result("Quotient"),
+        broadcast::list_result("Quotients"),
+    ];
 }
 
 impl NodeImpl for DivideNode {
     fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
-        let a: f64 = ctx
-            .input_values
-            .first()
-            .and_then(|v| v.first())
-            .and_then(|d| d.value::<f64>().ok().copied())
-            .unwrap_or(0.0);
-
-        let b: f64 = ctx
-            .input_values
-            .get(1)
-            .and_then(|v| v.first())
-            .and_then(|d| d.value::<f64>().ok().copied())
-            .unwrap_or(0.0);
-
-        let result = if b == 0.0 { 0.0 } else { a / b };
-        ctx.output_writer.set(0, Data::new(result)?)?;
-        Ok(())
+        broadcast::apply(&ctx, Self::NAME, |a, b| if b == 0.0 { 0.0 } else { a / b })
     }
 }
 

--- a/src/node/operators/mod.rs
+++ b/src/node/operators/mod.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod add_list;
+pub mod broadcast;
 pub mod divide;
 pub mod divide_list;
 pub mod multiply;

--- a/src/node/operators/multiply.rs
+++ b/src/node/operators/multiply.rs
@@ -1,7 +1,14 @@
+//! Multiply operator node.
+//!
+//! Multiplies two numbers (A * B). Every operand carries a scalar port and a `List(Number)`
+//! alternative; see [`super::broadcast`] for the elementwise semantics.
+
 use crate::{
-    register_nodes, Data, DataType, ExecutionContext, NodeCategory, NodeImpl, NodeMeta, SlotDef,
+    node::operators::broadcast, register_nodes, ExecutionContext, NodeCategory, NodeImpl, NodeMeta,
+    SlotDef,
 };
 
+/// Multiplies two numbers (A * B)
 #[derive(Debug)]
 pub struct MultiplyNode;
 
@@ -9,45 +16,20 @@ impl NodeMeta for MultiplyNode {
     const NAME: &'static str = "Multiply";
     const CATEGORY: NodeCategory = NodeCategory::Math;
     const INPUTS: &'static [SlotDef] = &[
-        SlotDef {
-            label: "A",
-            data_type: DataType::Number,
-            max_connections: Some(1),
-            inspector_visible: true,
-        },
-        SlotDef {
-            label: "B",
-            data_type: DataType::Number,
-            max_connections: Some(1),
-            inspector_visible: true,
-        },
+        broadcast::number_operand("A"),
+        broadcast::number_operand("B"),
+        broadcast::list_operand("A[]"),
+        broadcast::list_operand("B[]"),
     ];
-    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
-        label: "Product",
-        data_type: DataType::Number,
-        max_connections: None,
-        inspector_visible: true,
-    }];
+    const OUTPUTS: &'static [SlotDef] = &[
+        broadcast::number_result("Product"),
+        broadcast::list_result("Products"),
+    ];
 }
 
 impl NodeImpl for MultiplyNode {
     fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
-        let a: f64 = ctx
-            .input_values
-            .first()
-            .and_then(|v| v.first())
-            .and_then(|d| d.value::<f64>().ok().copied())
-            .unwrap_or(0.0);
-
-        let b: f64 = ctx
-            .input_values
-            .get(1)
-            .and_then(|v| v.first())
-            .and_then(|d| d.value::<f64>().ok().copied())
-            .unwrap_or(0.0);
-
-        ctx.output_writer.set(0, Data::new(a * b)?)?;
-        Ok(())
+        broadcast::apply(&ctx, Self::NAME, |a, b| a * b)
     }
 }
 

--- a/src/node/operators/subtract.rs
+++ b/src/node/operators/subtract.rs
@@ -1,7 +1,14 @@
+//! Subtract operator node.
+//!
+//! Subtracts B from A (A - B). Every operand carries a scalar port and a `List(Number)`
+//! alternative; see [`super::broadcast`] for the elementwise semantics.
+
 use crate::{
-    register_nodes, Data, DataType, ExecutionContext, NodeCategory, NodeImpl, NodeMeta, SlotDef,
+    node::operators::broadcast, register_nodes, ExecutionContext, NodeCategory, NodeImpl, NodeMeta,
+    SlotDef,
 };
 
+/// Subtracts B from A (A - B)
 #[derive(Debug)]
 pub struct SubtractNode;
 
@@ -9,45 +16,20 @@ impl NodeMeta for SubtractNode {
     const NAME: &'static str = "Subtract";
     const CATEGORY: NodeCategory = NodeCategory::Math;
     const INPUTS: &'static [SlotDef] = &[
-        SlotDef {
-            label: "A",
-            data_type: DataType::Number,
-            max_connections: Some(1),
-            inspector_visible: true,
-        },
-        SlotDef {
-            label: "B",
-            data_type: DataType::Number,
-            max_connections: Some(1),
-            inspector_visible: true,
-        },
+        broadcast::number_operand("A"),
+        broadcast::number_operand("B"),
+        broadcast::list_operand("A[]"),
+        broadcast::list_operand("B[]"),
     ];
-    const OUTPUTS: &'static [SlotDef] = &[SlotDef {
-        label: "Difference",
-        data_type: DataType::Number,
-        max_connections: None,
-        inspector_visible: true,
-    }];
+    const OUTPUTS: &'static [SlotDef] = &[
+        broadcast::number_result("Difference"),
+        broadcast::list_result("Differences"),
+    ];
 }
 
 impl NodeImpl for SubtractNode {
     fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
-        let a: f64 = ctx
-            .input_values
-            .first()
-            .and_then(|v| v.first())
-            .and_then(|d| d.value::<f64>().ok().copied())
-            .unwrap_or(0.0);
-
-        let b: f64 = ctx
-            .input_values
-            .get(1)
-            .and_then(|v| v.first())
-            .and_then(|d| d.value::<f64>().ok().copied())
-            .unwrap_or(0.0);
-
-        ctx.output_writer.set(0, Data::new(a - b)?)?;
-        Ok(())
+        broadcast::apply(&ctx, Self::NAME, |a, b| a - b)
     }
 }
 

--- a/src/node_graph/path_api.rs
+++ b/src/node_graph/path_api.rs
@@ -971,13 +971,13 @@ mod tests {
         let ns = graph.node_states.read().expect("read node_states");
         assert_eq!(
             ns.input_slot_count(&add_path),
-            2,
-            "Add should have 2 input slots at depth-2 path",
+            <crate::AddNode as crate::NodeMeta>::INPUTS.len(),
+            "Add's inputs should be recovered from the inventory entry",
         );
         assert_eq!(
             ns.output_slot_count(&add_path),
-            1,
-            "Add should have 1 output slot at depth-2 path",
+            <crate::AddNode as crate::NodeMeta>::OUTPUTS.len(),
+            "Add's outputs should be recovered from the inventory entry",
         );
     }
 
@@ -1519,8 +1519,8 @@ mod tests {
         let (graph, add_path) = graph_with_subgraph_add_node();
         assert_eq!(
             graph.input_slot_count_at(&add_path),
-            2,
-            "Add has 2 input slots at depth-2 path",
+            <crate::AddNode as crate::NodeMeta>::INPUTS.len(),
+            "the depth-2 path reports the inner Add's own input count",
         );
     }
 
@@ -1529,8 +1529,8 @@ mod tests {
         let (graph, add_path) = graph_with_subgraph_add_node();
         assert_eq!(
             graph.output_slot_count_at(&add_path),
-            1,
-            "Add has 1 output slot at depth-2 path",
+            <crate::AddNode as crate::NodeMeta>::OUTPUTS.len(),
+            "the depth-2 path reports the inner Add's own output count",
         );
     }
 

--- a/src/node_graph/subgraph_helpers.rs
+++ b/src/node_graph/subgraph_helpers.rs
@@ -87,39 +87,56 @@ impl NodeGraph {
     ///
     /// Returns edges whose both endpoints are direct children of `node_id`'s
     /// SubGraph (i.e. both `from_node` and `to_node` are `sg_path.child(_)`).
+    ///
+    /// Ordering contract: edges are enumerated per destination child (in
+    /// child creation order), per input slot, in that slot's CONNECTION
+    /// order (`edges_for_input` preserves connect order). A consumer that
+    /// replays these edges into another graph therefore reproduces every
+    /// multi-connection slot's ordering exactly. A sweep over the
+    /// `HashMap<EdgeId, Edge>` store would yield hash order and scramble
+    /// multi-connection slots (e.g. a polygon's vertex suppliers).
     pub fn subgraph_edges(&self, node_id: &NodeId) -> Vec<EdgeInfo> {
         let sg_path = NodePath::root().child(*node_id);
         let ns = match self.node_states.read() {
             Ok(g) => g,
             Err(_) => return Vec::new(),
         };
-        let children: std::collections::HashSet<NodeId> = ns
-            .path_index_children_of(&sg_path)
-            .iter()
-            .copied()
-            .collect();
-        ns.edges()
-            .iter()
-            .filter(|(_, edge)| {
-                // Both endpoints must be direct children of the SubGraph.
-                edge.from_node
-                    .leaf()
-                    .map(|id| children.contains(&id))
-                    .unwrap_or(false)
-                    && edge
-                        .to_node
+        let ordered_children: Vec<NodeId> = ns.path_index_children_of(&sg_path).to_vec();
+        let children: std::collections::HashSet<NodeId> =
+            ordered_children.iter().copied().collect();
+        let mut result = Vec::new();
+        for child in &ordered_children {
+            let child_path = sg_path.child(*child);
+            let slot_count = ns.input_slot_count(&child_path);
+            for idx in 0..slot_count {
+                let Some(slot) = ns.input_slot(&child_path, idx) else {
+                    continue;
+                };
+                for edge_id in ns.edges_for_input(&slot.id) {
+                    let Some(edge) = ns.get_edge(edge_id) else {
+                        continue;
+                    };
+                    // The destination is this child by construction; the
+                    // source must also be a direct child of the SubGraph.
+                    let from_inside = edge
+                        .from_node
                         .leaf()
                         .map(|id| children.contains(&id))
-                        .unwrap_or(false)
-            })
-            .map(|(id, edge)| EdgeInfo {
-                id: *id,
-                from_node: edge.from_node.clone(),
-                from_output: edge.from_output_slot_index,
-                to_node: edge.to_node.clone(),
-                to_input: edge.to_input_slot_index,
-            })
-            .collect()
+                        .unwrap_or(false);
+                    if !from_inside {
+                        continue;
+                    }
+                    result.push(EdgeInfo {
+                        id: *edge_id,
+                        from_node: edge.from_node.clone(),
+                        from_output: edge.from_output_slot_index,
+                        to_node: edge.to_node.clone(),
+                        to_input: edge.to_input_slot_index,
+                    });
+                }
+            }
+        }
+        result
     }
 
     // === SubGraph port management ===
@@ -1187,6 +1204,45 @@ mod tests {
         assert!(
             locked_of(out_proxy).contains("mand_out"),
             "output lock stamped"
+        );
+    }
+
+    #[test]
+    fn subgraph_edges_preserve_per_slot_connection_order() {
+        let mut graph = crate::NodeGraph::new().expect("create graph");
+        let sg = graph
+            .add_subgraph_at(&crate::NodePath::root(), "Order")
+            .expect("create subgraph");
+        let sg_path = crate::NodePath::root().child(sg);
+
+        let sink = graph
+            .create_node_by_name_at(&sg_path, "AddList")
+            .expect("create AddList sink");
+        let sink_path = sg_path.child(sink);
+
+        // Connect eight suppliers in a known order; with eight edges in
+        // one multi-connection slot, a hash-order enumeration virtually
+        // never matches the connect order, so this pins the contract.
+        let mut suppliers = Vec::new();
+        for _ in 0..8 {
+            let n = graph
+                .create_node_by_name_at(&sg_path, "Number")
+                .expect("create Number supplier");
+            graph
+                .connect_nodes_at(&sg_path.child(n), 0, &sink_path, 0)
+                .expect("connect supplier");
+            suppliers.push(n);
+        }
+
+        let into_sink: Vec<crate::NodeId> = graph
+            .subgraph_edges(&sg)
+            .into_iter()
+            .filter(|e| e.to_node.leaf() == Some(sink))
+            .map(|e| e.from_node.leaf().expect("leaf"))
+            .collect();
+        assert_eq!(
+            into_sink, suppliers,
+            "subgraph_edges must enumerate a multi-connection slot's edges in connect order"
         );
     }
 }


### PR DESCRIPTION
## Summary

Two changes the revion `refactor/bim-subgraph-basic-nodes` program depends on (merge this first):

1. **`subgraph_edges` now enumerates edges in per-slot connection order** instead of sweeping the `HashMap<EdgeId, Edge>` store in hash order. Any consumer replaying those edges into another graph (revion's variant-template replay) used to scramble every multi-connection slot's ordering — a polygon wired vertex-by-vertex came back with its corners shuffled (the furniture plan-symbol bowtie bug). The ordering contract is documented on the method and pinned by a test (8 suppliers into one multi-connection slot must come back in connect order).
2. **`Add` / `Subtract` / `Multiply` / `Divide` gain a `List(Number)` broadcast form** (typed alternative slots, elementwise with scalar broadcast, length mismatch = typed error) — the generic map that replaces revion's abolished Expression list broadcast. List slots follow the per-element-slot pattern; the existing `AddList`-style fan-in reducers are untouched.

## Verification

- `cargo nextest run`: 143 passed
- `cargo clippy --all-targets --all-features`: clean
- Downstream: revion's full suite (4070 workspace / 3089 modeling_app) + 5 native e2e scenarios pass against this branch.