### PR TITLE
feat: Value-based execution cutoff and structural generation counter

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -14,7 +14,7 @@ pub use primitives::*;
 pub use subgraph::*;
 pub use type_info::*;
 
-use crate::{impl_entity_id, AsAny, NodeManager};
+use crate::{impl_entity_id, AsAny, Data, NodeManager};
 use std::{any::Any, fmt::Debug, future::Future, pin::Pin};
 
 impl_entity_id!(NodeId);
@@ -45,6 +45,69 @@ pub enum NodeExecutionKind {
     /// I/O-bound. Must yield to an async runtime via the future returned
     /// from `prepare_async`.
     AsyncIo,
+}
+
+/// Whether a node takes part in **value-based execution cutoff**.
+///
+/// The executor's dirty plan is pure reachability: everything downstream
+/// of a changed node is replanned. Reachability cannot know that a node
+/// re-ran and produced the *same* values as last time, so an unchanged
+/// result still drags its whole downstream cone through a re-execution.
+///
+/// A node that opts in lets the executor answer that question. After the
+/// node runs, the executor hands it the outputs cached BEFORE the run and
+/// the ones now in the cache, and asks
+/// [`NodeImpl::outputs_equivalent`]. When the answer is "equivalent", the
+/// node is not recorded as changed, and every planned node whose inputs
+/// all come from unchanged nodes is skipped for this pass — not executed,
+/// absent from [`crate::ExecutionResult::node_outputs`], and left with its
+/// cached outputs (still valid) and its clean dirty state intact.
+///
+/// # Default is off — on purpose
+///
+/// [`OutputCutoff::Disabled`] is the default, and it reproduces the
+/// reachability-only behaviour exactly: an executed node always counts as
+/// changed. Opting in is a per-node decision because the equality test is
+/// only worth its cost where a node is a genuine value boundary (a
+/// fan-in whose result is stable for most inputs, a filter that forwards
+/// its input untouched). Forcing a deep comparison of large payloads on
+/// every node would cost more than the re-execution it saves.
+///
+/// # What an opt-in promises
+///
+/// - **True equivalence.** `outputs_equivalent` must be reflexive,
+///   symmetric and transitive, and "equivalent" must mean *no downstream
+///   node can observe a difference*. Anything weaker (a tolerance, a
+///   subset comparison, a hash with collisions) turns into stale
+///   downstream values that no later execution will repair, because the
+///   skipped nodes are never marked dirty again.
+/// - **The outputs are the whole story.** Only nodes whose output slots
+///   fully determine what downstream sees may opt in. A node that
+///   forwards values by another route — notably
+///   [`crate::InterfaceNode`], whose consumers resolve through it rather
+///   than from its (never written) cache — must stay `Disabled`.
+/// - **Cheap.** The comparison runs on every execution of the node, so it
+///   must be cheaper than the downstream cone it can prune.
+///
+/// # Fail-open
+///
+/// Everything the executor cannot decide runs the node: a directly-dirty
+/// node (structural change, node-data update, edge change) always
+/// executes, a node with any changed upstream always executes, a node
+/// whose upstream cannot be resolved always executes, and a node that
+/// FAILED counts as changed so its downstream re-runs. Cutoff can only
+/// ever remove work that provably has no observable effect.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OutputCutoff {
+    /// Executing this node always counts as "outputs changed"; its
+    /// downstream cone always re-runs. Default — identical to the
+    /// behaviour before value-based cutoff existed.
+    #[default]
+    Disabled,
+    /// After each run the executor calls
+    /// [`NodeImpl::outputs_equivalent`] with the previous and current
+    /// outputs; an equivalent result stops propagation at this node.
+    Enabled,
 }
 
 /// `'static` boxed future returned by [`NodeImpl::prepare_async`].
@@ -91,6 +154,33 @@ pub trait NodeImpl: Debug + Send + Sync + AsAny {
              `execution_kind() == NodeExecutionKind::AsyncIo` and implement `prepare_async`",
             std::any::type_name::<Self>()
         ))
+    }
+
+    /// Whether this node takes part in value-based execution cutoff.
+    ///
+    /// Default is [`OutputCutoff::Disabled`] — executing the node always
+    /// counts as a change. Override to [`OutputCutoff::Enabled`] *and*
+    /// implement [`NodeImpl::outputs_equivalent`] to let an unchanged
+    /// result prune the downstream cone. Read the [`OutputCutoff`] docs
+    /// before opting in: an equality that is not a true equivalence
+    /// leaves permanently stale downstream values.
+    fn output_cutoff(&self) -> OutputCutoff {
+        OutputCutoff::Disabled
+    }
+
+    /// Are the outputs this node just produced equivalent to the ones it
+    /// had before the run?
+    ///
+    /// Called only when [`NodeImpl::output_cutoff`] is
+    /// [`OutputCutoff::Enabled`]. Both slices are indexed by output slot
+    /// index and are the same length as the node's output slot list; a
+    /// slot with no cached value (never written, or evicted) is `None`.
+    ///
+    /// Returning `true` means "no downstream node can observe a
+    /// difference" and lets the executor skip this node's downstream cone.
+    /// Returning `false` is always safe — it is the default behaviour.
+    fn outputs_equivalent(&self, _previous: &[Option<Data>], _current: &[Option<Data>]) -> bool {
+        false
     }
 
     /// Async preparation entry point for `AsyncIo` nodes.

--- a/src/node_graph/mod.rs
+++ b/src/node_graph/mod.rs
@@ -295,6 +295,30 @@ impl NodeGraph {
             .unwrap_or_default()
     }
 
+    /// The graph's structural generation — a monotone counter that moves
+    /// whenever the graph's SHAPE changes.
+    ///
+    /// "Shape" is everything a topology query can observe: which nodes
+    /// exist, which slots they carry (count, order, label, data type,
+    /// default value) and which edges connect them. Node *data* writes
+    /// (`update_node_data*`) and execution do NOT move it — they change
+    /// what a node computes, never how the graph is wired.
+    ///
+    /// This is the identity a consumer caches a graph-shaped projection
+    /// against: read it, build the projection, and rebuild only once the
+    /// value has moved. The counter is conservative — a mutation that
+    /// happens to leave the shape identical still bumps it — so a stale
+    /// cache is impossible and a redundant rebuild is merely wasted work.
+    ///
+    /// Returns `0` on a poisoned state lock, which reads as "the shape
+    /// may have changed" for any cache that stored a non-zero value.
+    pub fn structure_generation(&self) -> u64 {
+        self.node_states
+            .read()
+            .map(|ns| ns.structure_generation())
+            .unwrap_or(0)
+    }
+
     /// Get an edge by ID.
     pub fn get_edge_by_id(&self, edge_id: &EdgeId) -> Option<Edge> {
         let ns = self.node_states.read().ok()?;
@@ -374,6 +398,62 @@ impl NodeGraph {
 
 #[cfg(test)]
 mod tests {
+    use crate::{Data, NodeGraph, NodePath};
+
     #[test]
     fn test_execute() {}
+
+    /// The contract [`NodeGraph::structure_generation`] promises: it
+    /// moves on wiring changes and stands still on data writes and
+    /// execution. A projection cache keyed on it is only correct if BOTH
+    /// halves hold.
+    #[test]
+    fn structure_generation_moves_only_on_shape_changes() {
+        let mut graph = NodeGraph::new().expect("create graph");
+        let start = graph.structure_generation();
+
+        let sg = graph
+            .add_subgraph_at(&NodePath::root(), "SG")
+            .expect("add subgraph");
+        let after_node = graph.structure_generation();
+        assert!(after_node > start, "creating a node must move the counter");
+
+        let sg_path = NodePath::root().child(sg);
+        let a = graph
+            .create_node_by_name_at(&sg_path, "Number")
+            .expect("create Number a");
+        let b = graph
+            .create_node_by_name_at(&sg_path, "Add")
+            .expect("create Add b");
+        let after_children = graph.structure_generation();
+        assert!(after_children > after_node);
+
+        graph
+            .connect_nodes_at(&sg_path.child(a), 0, &sg_path.child(b), 0)
+            .expect("connect a → b");
+        let after_edge = graph.structure_generation();
+        assert!(after_edge > after_children, "an edge must move the counter");
+
+        // Data writes and execution leave the shape alone.
+        graph
+            .update_node_data_at(&sg_path.child(a), Data::new(7.0_f64).expect("number"))
+            .expect("write node data");
+        assert_eq!(
+            graph.structure_generation(),
+            after_edge,
+            "a node-data write must NOT move the counter",
+        );
+        graph.execute_sync().expect("execute");
+        assert_eq!(
+            graph.structure_generation(),
+            after_edge,
+            "execution must NOT move the counter",
+        );
+
+        graph.remove_node_at(&sg_path.child(b)).expect("remove b");
+        assert!(
+            graph.structure_generation() > after_edge,
+            "removing a node must move the counter",
+        );
+    }
 }

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -1347,26 +1347,34 @@ impl NodeGraph {
                     if output_count == 0 {
                         let input_count = ns.input_slot_count(node_path);
                         let mut slot_inputs = vec![None; input_count];
-                        for edge in ns.edges().values() {
-                            if edge.to_node == *node_path
-                                && (edge.to_input_slot_index) < slot_inputs.len()
-                            {
-                                // Follow through any `InterfaceNode` proxy on
-                                // the source side. SubGraph external output
-                                // edges have `edge.from_node = OutputProxy`,
-                                // which is a runtime no-op (Phase X2) and
-                                // never writes its own output cache, so a
-                                // direct `cache.outputs.get` would miss.
-                                if let Some(data) = resolve_value_through_interface(
-                                    &ns,
-                                    &cache,
-                                    &edge.from_node,
-                                    edge.from_output_slot_index,
-                                    edge.from_output_slot_id,
-                                    &mut HashSet::new(),
-                                ) {
-                                    slot_inputs[edge.to_input_slot_index] = Some(data);
-                                }
+                        // Read the sink's OWN incoming edges through the
+                        // reverse index — the mirror of the outgoing walk
+                        // below. Filtering every edge in the graph here
+                        // made one executed sink cost a pass over the
+                        // whole project, i.e. an `O(sinks x E)` term on
+                        // every execute.
+                        for edge_id in ns.incoming_edges_at(node_path) {
+                            let Some(edge) = ns.get_edge(edge_id) else {
+                                continue;
+                            };
+                            if edge.to_input_slot_index >= slot_inputs.len() {
+                                continue;
+                            }
+                            // Follow through any `InterfaceNode` proxy on
+                            // the source side. SubGraph external output
+                            // edges have `edge.from_node = OutputProxy`,
+                            // which is a runtime no-op (Phase X2) and
+                            // never writes its own output cache, so a
+                            // direct `cache.outputs.get` would miss.
+                            if let Some(data) = resolve_value_through_interface(
+                                &ns,
+                                &cache,
+                                &edge.from_node,
+                                edge.from_output_slot_index,
+                                edge.from_output_slot_id,
+                                &mut HashSet::new(),
+                            ) {
+                                slot_inputs[edge.to_input_slot_index] = Some(data);
                             }
                         }
                         node_outputs.insert(node_path.clone(), slot_inputs);

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -1,3 +1,46 @@
+//! Graph execution: planning, scheduling and result collection.
+//!
+//! # How a pass runs
+//!
+//! 1. **Plan** (`build_execution_plan`) — snapshot the
+//!    directly-dirty *seed* set (nodes marked changed by a structural
+//!    edit, a node-data update or an edge change), BFS-close it over
+//!    outgoing edges, and topologically sort the closure into levels.
+//!    The dirty set is peeked, not drained, so a rejected plan stays
+//!    re-runnable.
+//! 2. **Validate** — reject a sync plan that reaches an `AsyncIo` node.
+//! 3. **Drain** — from here on, failures are per-node results, not a
+//!    graph-level error.
+//! 4. **Execute** level by level (rayon in [`ExecutionMode::Parallel`],
+//!    the calling thread in [`ExecutionMode::Sequential`]).
+//! 5. **Collect** the outputs, edge values and errors of the nodes that
+//!    actually ran.
+//!
+//! # Value-based execution cutoff
+//!
+//! The plan is reachability-only, so a node that re-runs and produces the
+//! *same* values as last time would still drag its whole downstream cone
+//! through a pointless re-execution. [`crate::OutputCutoff`] lets a node
+//! opt into being asked. During step 4 the executor keeps a
+//! `ChangeFrontier`: a planned node runs when it is directly dirty, or
+//! when at least one of its upstream sources produced changed outputs
+//! this pass. After an opted-in node runs, its cached-before and
+//! cached-after outputs are compared via
+//! [`crate::NodeImpl::outputs_equivalent`]; an equivalent result keeps it
+//! out of the frontier and its downstream cone is skipped.
+//!
+//! A skipped node is **not executed, not collected, and not dirty**: its
+//! cached outputs are still valid, so consumers that hold the previous
+//! [`ExecutionResult`] are already correct, and nothing re-marks it for a
+//! later pass. Only failures re-mark (`restore_dirty_for_failed`).
+//!
+//! Cutoff is **off by default** — [`crate::OutputCutoff::Disabled`] makes
+//! an executed node always count as changed, which is exactly the
+//! behaviour before cutoff existed — and every undecidable case **fails
+//! open** (executes). Read the [`crate::OutputCutoff`] docs before opting
+//! a node in: the equality must be a true equivalence, because a skipped
+//! node is never revisited to repair a wrong answer.
+
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -10,8 +53,8 @@ use std::any::TypeId;
 use crate::{
     node_graph_system::NodeGraphSystem, BoxNodeFuture, ColorValue, Data, DataType, DataValue, Edge,
     EdgeId, ErrorTarget, ExecutionContext, GraphError, NodeEntity, NodeExecutionKind, NodeGraph,
-    NodeId, NodeImpl, NodeMeta, NodePath, OutputWriter, SharedExecutionCache, SharedNodeStates,
-    Vector3,
+    NodeId, NodeImpl, NodeMeta, NodePath, OutputCutoff, OutputWriter, SharedExecutionCache,
+    SharedNodeStates, Vector3,
 };
 
 /// Typed error returned by `NodeGraph::execute_sync` and `execute_async`.
@@ -62,16 +105,24 @@ impl std::error::Error for GraphExecutionError {}
 /// it, so a `RequiresAsyncExecution` rejection leaves the graph
 /// re-executable from the same dirty state.
 struct ExecutionPlan {
-    /// Snapshot of node paths that were dirty when the plan was built.
-    /// The executor drains the underlying `NodeStates::changed_nodes`
-    /// only after API validation succeeds.
+    /// The directly-dirty seed set the plan was grown from: nodes marked
+    /// changed by a structural edit, a node-data update or an edge
+    /// change. These always execute — value-based cutoff only ever
+    /// prunes nodes reached transitively.
+    seed_nodes: HashSet<NodePath>,
+    /// Snapshot of node paths that were dirty when the plan was built —
+    /// the downstream closure of `seed_nodes`. The executor drains the
+    /// underlying `NodeStates::changed_nodes` only after API validation
+    /// succeeds.
     dirty_nodes: HashSet<NodePath>,
     /// Topologically grouped node levels — same-level nodes have no
     /// data dependencies on each other and may run in parallel.
     levels: Vec<Vec<NodePath>>,
-    /// Flattened executed-node list in topological order, for output
-    /// collection.
-    executed_node_paths: Vec<NodePath>,
+    /// Flattened planned-node list in topological order. Value-based
+    /// cutoff may skip a subset of these at run time, so the executor
+    /// collects outputs from the nodes it actually ran, not from this
+    /// list.
+    planned_node_paths: Vec<NodePath>,
     /// Removed nodes drained from bookkeeping at plan time (they don't
     /// participate in execution but are reported in `ExecutionResult`).
     /// Removal bookkeeping is id-keyed (the Remove API takes a
@@ -81,8 +132,155 @@ struct ExecutionPlan {
 
 impl ExecutionPlan {
     fn is_empty(&self) -> bool {
-        self.executed_node_paths.is_empty()
+        self.planned_node_paths.is_empty()
     }
+}
+
+/// Value-based execution cutoff bookkeeping for one execution pass.
+///
+/// The dirty plan is reachability-only: it names every node downstream of
+/// a change. This tracker narrows that to the nodes whose inputs actually
+/// moved, by recording which nodes produced *changed* outputs as the
+/// levels are executed. A planned node runs when it is directly dirty, or
+/// when at least one of its upstream sources is in the changed set.
+///
+/// Nodes that do not opt into [`OutputCutoff::Enabled`] are always
+/// recorded as changed after they run, so a graph of default nodes
+/// executes exactly the plan — the behaviour before cutoff existed.
+///
+/// # SubGraph boundaries are looked through
+///
+/// [`crate::InterfaceNode`] is one node carrying ALL of a SubGraph's
+/// external ports, and it is a runtime no-op: consumers resolve their
+/// value THROUGH it (`resolve_value_through_interface`), never from its
+/// cache. Treating it as an ordinary source would collapse every port
+/// into a single change signal — one changed external input would mark
+/// every node inside the SubGraph as having a changed upstream, and no
+/// cutoff inside a SubGraph could ever fire. So the frontier resolves an
+/// interface source exactly the way the value resolver does: back through
+/// the proxy's input slot of the same index to whatever really feeds it.
+///
+/// Every undecidable case fails open (executes). See [`OutputCutoff`].
+struct ChangeFrontier {
+    /// Directly-dirty nodes: they execute no matter what their upstreams
+    /// did.
+    seed: HashSet<NodePath>,
+    /// Nodes whose outputs changed during this pass; the propagation
+    /// front the skip test consults.
+    changed: HashSet<NodePath>,
+}
+
+impl ChangeFrontier {
+    fn new(seed: HashSet<NodePath>) -> Self {
+        Self {
+            seed,
+            changed: HashSet::new(),
+        }
+    }
+
+    /// Whether `path` must run in this pass.
+    ///
+    /// True when the node is directly dirty, when any upstream source is
+    /// in the changed set, or when its upstream topology cannot be
+    /// resolved (fail open). A node with no incoming edges at all can
+    /// only be in the plan as a seed, but is executed anyway if it
+    /// somehow is not — an unexecuted source node would be a silent
+    /// hole in the result.
+    fn must_execute(
+        &self,
+        path: &NodePath,
+        ns: &crate::node_graph::node_state::NodeStates,
+    ) -> bool {
+        if self.seed.contains(path) {
+            return true;
+        }
+        let incoming = ns.incoming_edges_at(path);
+        if incoming.is_empty() {
+            return true;
+        }
+        incoming.iter().any(|edge_id| {
+            // An edge id with no edge behind it: the topology is not
+            // trustworthy for a skip decision.
+            ns.get_edge(edge_id).is_none_or(|edge| {
+                self.source_changed(
+                    ns,
+                    &edge.from_node,
+                    edge.from_output_slot_index,
+                    &mut HashSet::new(),
+                )
+            })
+        })
+    }
+
+    /// Did the value delivered on (`from_node`, `slot_index`) change in
+    /// this pass?
+    ///
+    /// The mirror image of `resolve_value_through_interface`: for an
+    /// ordinary node the answer is membership in the changed set; for an
+    /// [`crate::InterfaceNode`] the proxy is not the source, so the walk
+    /// continues through the proxy's input slot of the SAME index into
+    /// whatever feeds it.
+    ///
+    /// `visited` guards the same pathological proxy loop the value
+    /// resolver guards — only the interface walk can loop, so the set is
+    /// touched (and therefore allocated) only once a proxy is actually
+    /// in the path. A revisit means the topology cannot be decided,
+    /// which fails open.
+    fn source_changed(
+        &self,
+        ns: &crate::node_graph::node_state::NodeStates,
+        from_node: &NodePath,
+        from_output_slot_index: usize,
+        visited: &mut HashSet<(NodePath, usize)>,
+    ) -> bool {
+        let is_interface = ns
+            .get(from_node)
+            .map(|s| s.type_name == crate::node::interface::InterfaceNode::NAME)
+            .unwrap_or(false);
+        if !is_interface {
+            return self.changed.contains(from_node);
+        }
+        if !visited.insert((from_node.clone(), from_output_slot_index)) {
+            return true;
+        }
+        // A directly-dirty proxy may forward something different for any
+        // reason the frontier cannot see from here — a slot default
+        // edited, a port added, an incoming edge re-wired. Do not try to
+        // be clever about which port it was.
+        if self.seed.contains(from_node) {
+            return true;
+        }
+        let Some(input_slot) = ns.input_slot(from_node, from_output_slot_index) else {
+            return true;
+        };
+        let upstream_edges = ns.edges_for_input(&input_slot.id);
+        if upstream_edges.is_empty() {
+            // The proxy forwards its slot default. A default only moves
+            // by an edit that marks the proxy itself dirty, which the
+            // seed check above already caught.
+            return false;
+        }
+        upstream_edges.iter().any(|edge_id| {
+            ns.get_edge(edge_id).is_none_or(|edge| {
+                self.source_changed(ns, &edge.from_node, edge.from_output_slot_index, visited)
+            })
+        })
+    }
+
+    /// Record that `path` produced outputs downstream must see.
+    fn mark_changed(&mut self, path: NodePath) {
+        self.changed.insert(path);
+    }
+}
+
+/// Outcome of one node run, as the cutoff tracker needs to see it.
+struct NodeRun {
+    path: NodePath,
+    result: Result<(), String>,
+    /// `false` only when the node opted into [`OutputCutoff::Enabled`]
+    /// and reported its fresh outputs equivalent to the cached previous
+    /// ones. A failure always reports `true` (fail open).
+    outputs_changed: bool,
 }
 
 /// Execution event for progress tracking during graph execution.
@@ -623,6 +821,32 @@ fn validate_async_in_sync_plan(
     }
 }
 
+/// Snapshot the cached output values of `path`, indexed by output slot.
+///
+/// Used by value-based cutoff to hand an opted-in node its "before" and
+/// "after" pictures. A slot with no cache entry (never written, or
+/// evicted) reads as `None`, which makes a first run compare unequal
+/// against anything the node writes — the fail-open direction.
+fn snapshot_outputs(
+    path: &NodePath,
+    shared_cache: &SharedExecutionCache,
+    shared_node_states: &SharedNodeStates,
+) -> Vec<Option<Data>> {
+    let Ok(ns) = shared_node_states.read() else {
+        return Vec::new();
+    };
+    let Ok(cache) = shared_cache.read() else {
+        return Vec::new();
+    };
+    (0..ns.output_slot_count(path))
+        .map(|idx| {
+            ns.output_slot(path, idx)
+                .and_then(|slot| cache.outputs.get(&slot.id))
+                .map(|data| data.share())
+        })
+        .collect()
+}
+
 /// Execute a single node synchronously.
 ///
 /// Locks the nodes map only long enough to clone out the node entity, then
@@ -634,15 +858,22 @@ fn validate_async_in_sync_plan(
 ///
 /// Wraps execution in `catch_unwind` so a single node panic does not abort
 /// the surrounding rayon level.
+///
+/// When the node opts into [`OutputCutoff::Enabled`], its cached outputs
+/// are snapshotted before the run and compared against the post-run cache
+/// via [`NodeImpl::outputs_equivalent`]; the verdict rides back on
+/// [`NodeRun::outputs_changed`]. Default nodes pay nothing for this — no
+/// snapshot is taken and the run always reports "changed".
 fn execute_node_sync(
     path: NodePath,
     shared_nodes: &crate::SharedNodes,
     shared_cache: &SharedExecutionCache,
     shared_node_states: &SharedNodeStates,
     on_progress: &(dyn Fn(ExecutionEvent) + Send + Sync),
-) -> (NodePath, Result<(), String>) {
+) -> NodeRun {
     on_progress(ExecutionEvent::Started(path.clone()));
 
+    let mut outputs_changed = true;
     let result: Result<(), String> = {
         let entity = {
             let nodes_guard = match shared_nodes.lock() {
@@ -652,15 +883,40 @@ fn execute_node_sync(
                         path.clone(),
                         "Lock poisoned".to_string(),
                     ));
-                    return (path, Err("Lock poisoned".to_string()));
+                    return NodeRun {
+                        path,
+                        result: Err("Lock poisoned".to_string()),
+                        outputs_changed: true,
+                    };
                 }
             };
             nodes_guard.get(&path).map(Arc::clone)
         };
 
         let Some(node_entity) = entity else {
+            // No entity to run: nothing was written, so nothing changed.
+            // Treated as changed anyway — a missing entity is a broken
+            // graph, not a value-stability claim.
             on_progress(ExecutionEvent::Completed(path.clone()));
-            return (path, Ok(()));
+            return NodeRun {
+                path,
+                result: Ok(()),
+                outputs_changed: true,
+            };
+        };
+
+        let cutoff = {
+            let node_read = match node_entity.read() {
+                Ok(r) => r,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            node_read.output_cutoff()
+        };
+        let previous_outputs = match cutoff {
+            OutputCutoff::Enabled => {
+                Some(snapshot_outputs(&path, shared_cache, shared_node_states))
+            }
+            OutputCutoff::Disabled => None,
         };
 
         let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -676,7 +932,7 @@ fn execute_node_sync(
             // before the next level starts.
         }));
 
-        match panic_result {
+        let result = match panic_result {
             Ok(res) => res,
             Err(panic_payload) => {
                 let msg = if let Some(s) = panic_payload.downcast_ref::<&str>() {
@@ -688,7 +944,19 @@ fn execute_node_sync(
                 };
                 Err(msg)
             }
+        };
+
+        // A failed node's outputs are indeterminate: keep propagating.
+        if let (Some(previous), Ok(())) = (previous_outputs, &result) {
+            let current = snapshot_outputs(&path, shared_cache, shared_node_states);
+            let node_read = match node_entity.read() {
+                Ok(r) => r,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            outputs_changed = !node_read.outputs_equivalent(&previous, &current);
         }
+
+        result
     };
 
     match &result {
@@ -696,7 +964,11 @@ fn execute_node_sync(
         Err(msg) => on_progress(ExecutionEvent::Failed(path.clone(), msg.clone())),
     }
 
-    (path, result)
+    NodeRun {
+        path,
+        result,
+        outputs_changed,
+    }
 }
 
 impl NodeGraph {
@@ -941,12 +1213,15 @@ impl NodeGraph {
 
         if changed.is_empty() {
             return Ok(ExecutionPlan {
+                seed_nodes: HashSet::new(),
                 dirty_nodes: HashSet::new(),
                 levels: Vec::new(),
-                executed_node_paths: Vec::new(),
+                planned_node_paths: Vec::new(),
                 removed_nodes: removed,
             });
         }
+
+        let seed_nodes = changed.clone();
 
         let dirty_nodes: HashSet<NodePath> = {
             let ns = self
@@ -973,15 +1248,16 @@ impl NodeGraph {
             .topological_sort(&dirty_nodes)
             .map_err(GraphExecutionError::PlanningFailed)?;
 
-        let executed_node_paths: Vec<NodePath> = levels
+        let planned_node_paths: Vec<NodePath> = levels
             .iter()
             .flat_map(|level| level.iter().cloned())
             .collect();
 
         Ok(ExecutionPlan {
+            seed_nodes,
             dirty_nodes,
             levels,
-            executed_node_paths,
+            planned_node_paths,
             removed_nodes: removed,
         })
     }
@@ -996,7 +1272,11 @@ impl NodeGraph {
     /// executes directly — there is no internal-graph recursion to inspect.
     fn validate_for_sync(&self, plan: &ExecutionPlan) -> Result<(), GraphExecutionError> {
         let shared_nodes = self.node_manager.nodes();
-        validate_async_in_sync_plan(&plan.executed_node_paths, &shared_nodes)
+        // Validated over the PLANNED set, not the eventually-executed
+        // one: the rejection must be decidable before anything runs, and
+        // rejecting a plan that value-based cutoff might have skipped
+        // past is the conservative direction.
+        validate_async_in_sync_plan(&plan.planned_node_paths, &shared_nodes)
     }
 
     /// Validate that the plan can run on the asynchronous kernel.
@@ -1032,11 +1312,21 @@ impl NodeGraph {
         }
     }
 
-    /// Collect outputs/edge_values/errors for the executed plan.
-    fn collect_outputs(&self, plan: &ExecutionPlan) -> ExecutionResult {
+    /// Collect outputs/edge_values/errors for the nodes that actually
+    /// ran.
+    ///
+    /// `executed_node_paths` is the subset of `plan.planned_node_paths`
+    /// the executor did not skip via value-based cutoff. Skipped nodes
+    /// are deliberately absent from the result: their cached outputs are
+    /// unchanged, so re-publishing them would only make consumers redo
+    /// work for values they already hold.
+    fn collect_outputs(
+        &self,
+        plan: &ExecutionPlan,
+        executed_node_paths: &[NodePath],
+    ) -> ExecutionResult {
         let shared_cache = self.cache.share();
         let shared_node_states = self.node_states.clone();
-        let executed_node_paths = &plan.executed_node_paths;
 
         let mut node_outputs: HashMap<NodePath, Vec<Option<Data>>> = HashMap::new();
         let mut edge_values: HashMap<EdgeId, EdgeValue> = HashMap::new();
@@ -1189,10 +1479,27 @@ impl NodeGraph {
         let shared_cache = self.cache.share();
         let shared_node_states = self.node_states.clone();
 
+        let mut frontier = ChangeFrontier::new(plan.seed_nodes.clone());
+        let mut executed_node_paths: Vec<NodePath> =
+            Vec::with_capacity(plan.planned_node_paths.len());
         let mut failed_paths: HashSet<NodePath> = HashSet::new();
         for level_nodes in &plan.levels {
-            let level_vec: Vec<NodePath> = level_nodes.clone();
-            let level_results: Vec<(NodePath, Result<(), String>)> = match mode {
+            // Value-based cutoff: a planned node whose inputs all come
+            // from nodes that did not change this pass is skipped —
+            // not executed, not collected, cache and dirty state
+            // untouched. Both scheduling modes take the same decision;
+            // only the dispatch of the survivors differs.
+            let level_vec: Vec<NodePath> = match self.node_states.read() {
+                Ok(ns) => level_nodes
+                    .iter()
+                    .filter(|path| frontier.must_execute(path, &ns))
+                    .cloned()
+                    .collect(),
+                // Unreadable node states: no basis for a skip decision,
+                // so run the whole level (fail open).
+                Err(_) => level_nodes.clone(),
+            };
+            let level_results: Vec<NodeRun> = match mode {
                 ExecutionMode::Sequential => level_vec
                     .into_iter()
                     .map(|path| {
@@ -1219,21 +1526,26 @@ impl NodeGraph {
                     .collect(),
             };
 
-            for (path, res) in level_results {
-                if let Err(msg) = res {
-                    self.add_error(GraphError::execution_at_path(&path, msg));
-                    failed_paths.insert(path);
+            for run in level_results {
+                if run.outputs_changed {
+                    frontier.mark_changed(run.path.clone());
                 }
+                if let Err(msg) = run.result {
+                    self.add_error(GraphError::execution_at_path(&run.path, msg));
+                    failed_paths.insert(run.path.clone());
+                }
+                executed_node_paths.push(run.path);
             }
         }
 
         // Per plan-14c §Dirty-State Rule, failures must preserve enough
         // dirty state for a later retry. Re-mark every failed node as
         // changed so the next `execute_*` call replans from the same
-        // failure point. Successful nodes stay clean.
+        // failure point. Successful nodes stay clean — and so do skipped
+        // ones, which never ran and whose cached outputs are still valid.
         self.restore_dirty_for_failed(failed_paths);
 
-        Ok(self.collect_outputs(&plan))
+        Ok(self.collect_outputs(&plan, &executed_node_paths))
     }
 
     /// Re-mark `failed_paths` as changed in `NodeStates`. Idempotent if
@@ -1292,12 +1604,30 @@ impl NodeGraph {
         let shared_cache = self.cache.share();
         let shared_node_states = self.node_states.clone();
 
+        let mut frontier = ChangeFrontier::new(plan.seed_nodes.clone());
+        let mut executed_node_paths: Vec<NodePath> =
+            Vec::with_capacity(plan.planned_node_paths.len());
         let mut failed_paths: HashSet<NodePath> = HashSet::new();
         for level_nodes in &plan.levels {
+            // Value-based cutoff, identical semantics to the sync
+            // kernel: skip a planned node whose every upstream is
+            // unchanged. `AsyncIo` nodes never opt in (their default
+            // `output_cutoff` is `Disabled`), so they always count as
+            // changed once they run — only the decision to run them at
+            // all is shared with the sync path.
+            let runnable: Vec<NodePath> = match self.node_states.read() {
+                Ok(ns) => level_nodes
+                    .iter()
+                    .filter(|path| frontier.must_execute(path, &ns))
+                    .cloned()
+                    .collect(),
+                Err(_) => level_nodes.clone(),
+            };
+
             // Partition dirty level into Sync/Async by execution_kind.
             let mut sync_paths: Vec<NodePath> = Vec::new();
             let mut async_paths: Vec<NodePath> = Vec::new();
-            for path in level_nodes {
+            for path in &runnable {
                 match node_execution_kind(path, &shared_nodes) {
                     Some(NodeExecutionKind::AsyncIo) => async_paths.push(path.clone()),
                     // Missing entity falls through to the sync path —
@@ -1311,7 +1641,7 @@ impl NodeGraph {
             // caller's runtime can offload via `spawn_blocking` if it
             // dislikes that — the plan-14c invariant is only that the
             // graph executor itself never calls `block_on`.
-            let sync_results: Vec<(NodePath, Result<(), String>)> = match mode {
+            let sync_results: Vec<NodeRun> = match mode {
                 ExecutionMode::Sequential => sync_paths
                     .into_iter()
                     .map(|path| {
@@ -1338,11 +1668,15 @@ impl NodeGraph {
                     .collect(),
             };
 
-            for (path, res) in &sync_results {
-                if let Err(msg) = res {
-                    self.add_error(GraphError::execution_at_path(path, msg.clone()));
-                    failed_paths.insert(path.clone());
+            for run in sync_results {
+                if run.outputs_changed {
+                    frontier.mark_changed(run.path.clone());
                 }
+                if let Err(msg) = run.result {
+                    self.add_error(GraphError::execution_at_path(&run.path, msg));
+                    failed_paths.insert(run.path.clone());
+                }
+                executed_node_paths.push(run.path);
             }
 
             // Async I/O work: prepare each future under a short read
@@ -1362,6 +1696,11 @@ impl NodeGraph {
                                     &path,
                                     "Lock poisoned".to_string(),
                                 ));
+                                // The node never ran, so nothing can be
+                                // claimed about its outputs: propagate
+                                // (fail open) rather than let the cutoff
+                                // silently prune its downstream.
+                                frontier.mark_changed(path);
                                 continue;
                             }
                         };
@@ -1398,14 +1737,18 @@ impl NodeGraph {
             let async_results = futures::future::join_all(async_futs).await;
 
             for (path, res) in async_results {
+                // `AsyncIo` nodes never opt into value-based cutoff, so
+                // running one always counts as a change.
+                frontier.mark_changed(path.clone());
                 match res {
-                    Ok(()) => on_progress(ExecutionEvent::Completed(path)),
+                    Ok(()) => on_progress(ExecutionEvent::Completed(path.clone())),
                     Err(msg) => {
                         on_progress(ExecutionEvent::Failed(path.clone(), msg.clone()));
                         self.add_error(GraphError::execution_at_path(&path, msg));
-                        failed_paths.insert(path);
+                        failed_paths.insert(path.clone());
                     }
                 }
+                executed_node_paths.push(path);
             }
         }
 
@@ -1413,7 +1756,7 @@ impl NodeGraph {
         // remote errors etc.) must leave the dirty plan re-runnable.
         self.restore_dirty_for_failed(failed_paths);
 
-        Ok(self.collect_outputs(&plan))
+        Ok(self.collect_outputs(&plan, &executed_node_paths))
     }
 }
 
@@ -2015,5 +2358,524 @@ mod sync_executor_tests {
             probe_output(&r, &probe_path),
             format!("/{}/{}", sg_id.id_string(), probe_id.id_string())
         );
+    }
+}
+
+#[cfg(test)]
+mod value_cutoff_tests {
+    //! Value-based execution cutoff ([`OutputCutoff`]): an opted-in node
+    //! whose fresh outputs equal its cached ones stops propagation, so
+    //! the planned nodes downstream of it are skipped for that pass.
+
+    use super::*;
+    use crate::{AddNode, NumberNode};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // ── Test nodes ────────────────────────────────────────────────
+
+    /// How many times [`QuantizeNode`] ran since the last reset.
+    static QUANTIZE_RUNS: AtomicUsize = AtomicUsize::new(0);
+    /// How many times [`PlainDoubleNode`] ran since the last reset.
+    static DOUBLE_RUNS: AtomicUsize = AtomicUsize::new(0);
+    /// How many times [`AlwaysFailsNode`] ran since the last reset.
+    static FAIL_RUNS: AtomicUsize = AtomicUsize::new(0);
+
+    /// Compare two output snapshots slot-by-slot as `f64`.
+    ///
+    /// A slot that is missing on exactly one side, or whose payload is
+    /// not a number, compares unequal — the fail-open direction.
+    fn number_slots_equal(previous: &[Option<Data>], current: &[Option<Data>]) -> bool {
+        previous.len() == current.len()
+            && previous
+                .iter()
+                .zip(current.iter())
+                .all(|(p, c)| match (p, c) {
+                    (Some(p), Some(c)) => match (p.value::<f64>(), c.value::<f64>()) {
+                        (Ok(p), Ok(c)) => p == c,
+                        _ => false,
+                    },
+                    (None, None) => true,
+                    _ => false,
+                })
+    }
+
+    /// Opted-in value boundary: emits `floor(input)`, so a range of
+    /// input values maps onto one output value. Stands in for a real
+    /// boundary node (a fan-in, a filter) whose result is stable across
+    /// most upstream edits.
+    #[derive(Debug)]
+    struct QuantizeNode;
+
+    impl crate::NodeMeta for QuantizeNode {
+        const NAME: &'static str = "CutoffQuantizeTestNode";
+        const CATEGORY: crate::NodeCategory = crate::NodeCategory::Math;
+        const INPUTS: &'static [crate::SlotDef] = &[crate::SlotDef {
+            label: "In",
+            data_type: DataType::Number,
+            max_connections: Some(1),
+            inspector_visible: true,
+        }];
+        const OUTPUTS: &'static [crate::SlotDef] = &[crate::SlotDef {
+            label: "Out",
+            data_type: DataType::Number,
+            max_connections: None,
+            inspector_visible: true,
+        }];
+    }
+
+    impl NodeImpl for QuantizeNode {
+        fn output_cutoff(&self) -> OutputCutoff {
+            OutputCutoff::Enabled
+        }
+
+        fn outputs_equivalent(&self, previous: &[Option<Data>], current: &[Option<Data>]) -> bool {
+            number_slots_equal(previous, current)
+        }
+
+        fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
+            QUANTIZE_RUNS.fetch_add(1, Ordering::SeqCst);
+            let input = ctx
+                .input_values
+                .first()
+                .and_then(|v| v.first())
+                .and_then(|d| d.value::<f64>().ok().copied())
+                .unwrap_or(0.0);
+            ctx.output_writer
+                .set(0, Data::new(input.floor()).map_err(|e| e.to_string())?)
+        }
+    }
+
+    crate::register_nodes!(QuantizeNode);
+
+    /// Same shape as [`QuantizeNode`] but WITHOUT the opt-in: the
+    /// control for "a default node never prunes, even when its outputs
+    /// are bit-identical".
+    #[derive(Debug)]
+    struct PlainDoubleNode;
+
+    impl crate::NodeMeta for PlainDoubleNode {
+        const NAME: &'static str = "CutoffPlainDoubleTestNode";
+        const CATEGORY: crate::NodeCategory = crate::NodeCategory::Math;
+        const INPUTS: &'static [crate::SlotDef] = &[crate::SlotDef {
+            label: "In",
+            data_type: DataType::Number,
+            max_connections: Some(1),
+            inspector_visible: true,
+        }];
+        const OUTPUTS: &'static [crate::SlotDef] = &[crate::SlotDef {
+            label: "Out",
+            data_type: DataType::Number,
+            max_connections: None,
+            inspector_visible: true,
+        }];
+    }
+
+    impl NodeImpl for PlainDoubleNode {
+        fn execute_sync(&self, ctx: ExecutionContext) -> Result<(), String> {
+            DOUBLE_RUNS.fetch_add(1, Ordering::SeqCst);
+            let input = ctx
+                .input_values
+                .first()
+                .and_then(|v| v.first())
+                .and_then(|d| d.value::<f64>().ok().copied())
+                .unwrap_or(0.0);
+            ctx.output_writer
+                .set(0, Data::new(input.floor()).map_err(|e| e.to_string())?)
+        }
+    }
+
+    crate::register_nodes!(PlainDoubleNode);
+
+    /// Always fails, so the dirty-restoration path can be observed
+    /// alongside skipping.
+    #[derive(Debug)]
+    struct AlwaysFailsNode;
+
+    impl crate::NodeMeta for AlwaysFailsNode {
+        const NAME: &'static str = "CutoffAlwaysFailsTestNode";
+        const CATEGORY: crate::NodeCategory = crate::NodeCategory::Math;
+        const INPUTS: &'static [crate::SlotDef] = &[crate::SlotDef {
+            label: "In",
+            data_type: DataType::Number,
+            max_connections: Some(1),
+            inspector_visible: true,
+        }];
+        const OUTPUTS: &'static [crate::SlotDef] = &[crate::SlotDef {
+            label: "Out",
+            data_type: DataType::Number,
+            max_connections: None,
+            inspector_visible: true,
+        }];
+    }
+
+    impl NodeImpl for AlwaysFailsNode {
+        fn execute_sync(&self, _ctx: ExecutionContext) -> Result<(), String> {
+            FAIL_RUNS.fetch_add(1, Ordering::SeqCst);
+            Err("CutoffAlwaysFails: deliberate failure (test fixture)".to_string())
+        }
+    }
+
+    crate::register_nodes!(AlwaysFailsNode);
+
+    // ── Helpers ───────────────────────────────────────────────────
+
+    fn path(id: NodeId) -> NodePath {
+        NodePath::root().child(id)
+    }
+
+    fn ran(result: &ExecutionResult, id: NodeId) -> bool {
+        result.node_outputs.contains_key(&path(id))
+    }
+
+    fn set_number(graph: &mut NodeGraph, id: NodeId, value: f64) {
+        graph
+            .update_node_data(&id, Data::new(value).unwrap())
+            .unwrap();
+    }
+
+    fn cached(graph: &NodeGraph, id: NodeId) -> Option<f64> {
+        graph
+            .get_output_value(&id, 0)
+            .and_then(|d| d.value::<f64>().ok().copied())
+    }
+
+    /// `Number → Quantize → Add(B) → Add(C)`: the canonical A→B→C chain
+    /// with the opted-in node at A.
+    fn build_chain() -> (NodeGraph, NodeId, NodeId, NodeId, NodeId) {
+        let mut graph = NodeGraph::new().unwrap();
+        let num = graph.create_node::<NumberNode>().unwrap();
+        let quant = graph.create_node::<QuantizeNode>().unwrap();
+        let b = graph.create_node::<AddNode>().unwrap();
+        let c = graph.create_node::<AddNode>().unwrap();
+        set_number(&mut graph, num, 1.2);
+        graph.connect_nodes(&num, 0, &quant, 0).unwrap();
+        graph.connect_nodes(&quant, 0, &b, 0).unwrap();
+        graph.connect_nodes(&b, 0, &c, 0).unwrap();
+        (graph, num, quant, b, c)
+    }
+
+    // ── (i) equal output → downstream skipped ─────────────────────
+
+    #[test]
+    fn equal_output_skips_the_downstream_cone_and_keeps_its_cached_values() {
+        let (mut graph, num, quant, b, c) = build_chain();
+        let first = graph.execute_sync().unwrap();
+        assert!(
+            ran(&first, b) && ran(&first, c),
+            "first pass runs everything"
+        );
+        assert_eq!(cached(&graph, c), Some(1.0));
+
+        // 1.2 → 1.7: the Number changes, `floor` does not.
+        QUANTIZE_RUNS.store(0, Ordering::SeqCst);
+        set_number(&mut graph, num, 1.7);
+        let second = graph.execute_sync().unwrap();
+
+        assert!(ran(&second, num), "the directly-dirty node always runs");
+        assert_eq!(
+            QUANTIZE_RUNS.load(Ordering::SeqCst),
+            1,
+            "the opted-in node itself still runs — cutoff is about its downstream",
+        );
+        assert!(ran(&second, quant), "an executed node reports its outputs");
+        assert!(
+            !ran(&second, b) && !ran(&second, c),
+            "an equivalent result stops propagation: B and C are skipped",
+        );
+        assert_eq!(
+            cached(&graph, b),
+            Some(1.0),
+            "a skipped node keeps its cached outputs",
+        );
+        assert_eq!(cached(&graph, c), Some(1.0));
+    }
+
+    /// A skipped node is not dirty: it never ran, but it also never
+    /// failed, so nothing re-marks it and the next execute is a no-op.
+    #[test]
+    fn skipped_nodes_are_left_clean_not_dirty() {
+        let (mut graph, num, _quant, _b, _c) = build_chain();
+        graph.execute_sync().unwrap();
+        set_number(&mut graph, num, 1.7);
+        graph.execute_sync().unwrap();
+
+        let third = graph.execute_sync().unwrap();
+        assert!(
+            third.node_outputs.is_empty(),
+            "skipping must not leave dirty state behind, got {:?}",
+            third.node_outputs.keys().collect::<Vec<_>>(),
+        );
+    }
+
+    // ── (ii) differing output → everything runs ───────────────────
+
+    #[test]
+    fn differing_output_propagates_to_the_whole_cone() {
+        let (mut graph, num, quant, b, c) = build_chain();
+        graph.execute_sync().unwrap();
+
+        // 1.2 → 3.4: `floor` moves from 1 to 3.
+        set_number(&mut graph, num, 3.4);
+        let second = graph.execute_sync().unwrap();
+
+        assert!(
+            ran(&second, num) && ran(&second, quant) && ran(&second, b) && ran(&second, c),
+            "a changed value re-runs the full planned cone",
+        );
+        assert_eq!(cached(&graph, c), Some(3.0));
+    }
+
+    // ── (iii) default node → never prunes ─────────────────────────
+
+    #[test]
+    fn a_default_node_never_prunes_even_with_identical_outputs() {
+        let mut graph = NodeGraph::new().unwrap();
+        let num = graph.create_node::<NumberNode>().unwrap();
+        let plain = graph.create_node::<PlainDoubleNode>().unwrap();
+        let b = graph.create_node::<AddNode>().unwrap();
+        let c = graph.create_node::<AddNode>().unwrap();
+        set_number(&mut graph, num, 1.2);
+        graph.connect_nodes(&num, 0, &plain, 0).unwrap();
+        graph.connect_nodes(&plain, 0, &b, 0).unwrap();
+        graph.connect_nodes(&b, 0, &c, 0).unwrap();
+        graph.execute_sync().unwrap();
+
+        // Same edit as the opted-in case: `floor` is identical, but the
+        // node did not opt in, so nothing is skipped.
+        DOUBLE_RUNS.store(0, Ordering::SeqCst);
+        set_number(&mut graph, num, 1.7);
+        let second = graph.execute_sync().unwrap();
+
+        assert_eq!(DOUBLE_RUNS.load(Ordering::SeqCst), 1);
+        assert!(
+            ran(&second, plain) && ran(&second, b) && ran(&second, c),
+            "OutputCutoff::Disabled reproduces reachability-only execution",
+        );
+    }
+
+    // ── (iv) diamond fan-in ───────────────────────────────────────
+
+    /// A join fed by one changed and one unchanged branch executes: a
+    /// single changed upstream is enough.
+    #[test]
+    fn a_join_with_one_changed_branch_executes() {
+        let mut graph = NodeGraph::new().unwrap();
+        let left_num = graph.create_node::<NumberNode>().unwrap();
+        let right_num = graph.create_node::<NumberNode>().unwrap();
+        let left = graph.create_node::<QuantizeNode>().unwrap();
+        let right = graph.create_node::<QuantizeNode>().unwrap();
+        let join = graph.create_node::<AddNode>().unwrap();
+        let tail = graph.create_node::<AddNode>().unwrap();
+        set_number(&mut graph, left_num, 1.2);
+        set_number(&mut graph, right_num, 10.2);
+        graph.connect_nodes(&left_num, 0, &left, 0).unwrap();
+        graph.connect_nodes(&right_num, 0, &right, 0).unwrap();
+        graph.connect_nodes(&left, 0, &join, 0).unwrap();
+        graph.connect_nodes(&right, 0, &join, 1).unwrap();
+        graph.connect_nodes(&join, 0, &tail, 0).unwrap();
+        graph.execute_sync().unwrap();
+        assert_eq!(cached(&graph, join), Some(11.0));
+
+        // Left stays put across the quantiser; right moves.
+        set_number(&mut graph, left_num, 1.7);
+        set_number(&mut graph, right_num, 12.3);
+        let second = graph.execute_sync().unwrap();
+
+        assert!(
+            ran(&second, join),
+            "a join with any changed upstream must execute",
+        );
+        assert!(
+            ran(&second, left),
+            "the absorbed branch's boundary node still runs; it just does not propagate",
+        );
+        assert!(ran(&second, tail), "and so must its downstream");
+        assert_eq!(
+            cached(&graph, join),
+            Some(13.0),
+            "the join still reads the UNCHANGED branch's cached value",
+        );
+    }
+
+    /// Both branches equivalent → the join is skipped.
+    #[test]
+    fn a_join_with_no_changed_branch_is_skipped() {
+        let mut graph = NodeGraph::new().unwrap();
+        let left_num = graph.create_node::<NumberNode>().unwrap();
+        let right_num = graph.create_node::<NumberNode>().unwrap();
+        let left = graph.create_node::<QuantizeNode>().unwrap();
+        let right = graph.create_node::<QuantizeNode>().unwrap();
+        let join = graph.create_node::<AddNode>().unwrap();
+        set_number(&mut graph, left_num, 1.2);
+        set_number(&mut graph, right_num, 10.2);
+        graph.connect_nodes(&left_num, 0, &left, 0).unwrap();
+        graph.connect_nodes(&right_num, 0, &right, 0).unwrap();
+        graph.connect_nodes(&left, 0, &join, 0).unwrap();
+        graph.connect_nodes(&right, 0, &join, 1).unwrap();
+        graph.execute_sync().unwrap();
+
+        set_number(&mut graph, left_num, 1.7);
+        set_number(&mut graph, right_num, 10.9);
+        let second = graph.execute_sync().unwrap();
+
+        assert!(!ran(&second, join));
+        assert_eq!(cached(&graph, join), Some(11.0));
+    }
+
+    // ── (v) failure interaction ───────────────────────────────────
+
+    /// A failed node is re-marked dirty and therefore re-runs on the
+    /// next pass EVEN IF its upstream is unchanged — the restored dirty
+    /// mark is a seed, and seeds always execute. A skipped node gets no
+    /// such mark.
+    #[test]
+    fn a_failed_node_still_retries_while_skipped_nodes_do_not() {
+        let mut graph = NodeGraph::new().unwrap();
+        let num = graph.create_node::<NumberNode>().unwrap();
+        let quant = graph.create_node::<QuantizeNode>().unwrap();
+        let failing = graph.create_node::<AlwaysFailsNode>().unwrap();
+        let skipped = graph.create_node::<AddNode>().unwrap();
+        set_number(&mut graph, num, 1.2);
+        graph.connect_nodes(&num, 0, &quant, 0).unwrap();
+        graph.connect_nodes(&quant, 0, &failing, 0).unwrap();
+        graph.connect_nodes(&quant, 0, &skipped, 0).unwrap();
+
+        let first = graph.execute_sync().unwrap();
+        assert!(first.errors.contains_key(&path(failing)));
+        assert!(ran(&first, skipped));
+
+        // An edit the quantiser absorbs. `skipped` has no changed
+        // upstream; `failing` is dirty from its own failure.
+        FAIL_RUNS.store(0, Ordering::SeqCst);
+        set_number(&mut graph, num, 1.7);
+        let second = graph.execute_sync().unwrap();
+
+        assert_eq!(
+            FAIL_RUNS.load(Ordering::SeqCst),
+            1,
+            "the failed node is re-marked dirty and retries",
+        );
+        assert!(
+            !ran(&second, skipped),
+            "the sibling with no changed upstream is skipped",
+        );
+        assert!(
+            second.errors.contains_key(&path(failing)),
+            "the retry's failure is reported again",
+        );
+    }
+
+    /// A failing opted-in node counts as changed: its downstream must
+    /// not be pruned on the strength of a comparison that never ran.
+    #[test]
+    fn a_failing_node_propagates_even_though_its_outputs_did_not_move() {
+        let mut graph = NodeGraph::new().unwrap();
+        let num = graph.create_node::<NumberNode>().unwrap();
+        let failing = graph.create_node::<AlwaysFailsNode>().unwrap();
+        let downstream = graph.create_node::<AddNode>().unwrap();
+        set_number(&mut graph, num, 1.0);
+        graph.connect_nodes(&num, 0, &failing, 0).unwrap();
+        graph.connect_nodes(&failing, 0, &downstream, 0).unwrap();
+
+        graph.execute_sync().unwrap();
+        set_number(&mut graph, num, 2.0);
+        let second = graph.execute_sync().unwrap();
+
+        assert!(
+            ran(&second, downstream),
+            "a failed node fails open — its downstream still runs",
+        );
+    }
+
+    // ── (vi) SubGraph interface transparency ──────────────────────
+
+    /// `Number → InputProxy → Quantize → OutputProxy → Add`, wired the
+    /// way a SubGraph boundary is: the proxies never write their own
+    /// cache, and consumers resolve through them. Skipping a proxy must
+    /// therefore be invisible, and a later pass that DOES change the
+    /// value must still deliver it through the proxy chain.
+    #[test]
+    fn cutoff_across_a_subgraph_interface_boundary() {
+        let mut graph = NodeGraph::new().unwrap();
+        let sg = graph.add_subgraph_at(&NodePath::root(), "SG").unwrap();
+        graph
+            .add_subgraph_input(&sg, "In", DataType::Number)
+            .unwrap();
+        graph
+            .add_subgraph_output(&sg, "Out", DataType::Number)
+            .unwrap();
+        let (in_proxy, out_proxy) = graph.subgraph_proxy_ids(&sg).unwrap();
+        let sg_path = NodePath::root().child(sg);
+        let in_path = sg_path.child(in_proxy);
+        let out_path = sg_path.child(out_proxy);
+
+        let num = graph.create_node::<NumberNode>().unwrap();
+        let quant_id = graph
+            .create_node_by_name_at(&sg_path, QuantizeNode::NAME)
+            .unwrap();
+        let quant_path = sg_path.child(quant_id);
+        let sink = graph.create_node::<AddNode>().unwrap();
+        set_number(&mut graph, num, 1.2);
+
+        graph.connect_nodes_at(&path(num), 0, &in_path, 0).unwrap();
+        graph.connect_nodes_at(&in_path, 0, &quant_path, 0).unwrap();
+        graph
+            .connect_nodes_at(&quant_path, 0, &out_path, 0)
+            .unwrap();
+        graph
+            .connect_nodes_at(&out_path, 0, &path(sink), 0)
+            .unwrap();
+
+        graph.execute_sync().unwrap();
+        assert_eq!(
+            cached(&graph, sink),
+            Some(1.0),
+            "the value crosses both proxies"
+        );
+
+        // Absorbed edit: the output proxy and the sink are skipped.
+        set_number(&mut graph, num, 1.7);
+        let second = graph.execute_sync().unwrap();
+        assert!(
+            !second.node_outputs.contains_key(&out_path),
+            "the output proxy has no changed upstream and is skipped",
+        );
+        assert!(!ran(&second, sink));
+        assert_eq!(cached(&graph, sink), Some(1.0));
+
+        // Real edit: resolution through the previously-skipped proxy
+        // still delivers the fresh value.
+        set_number(&mut graph, num, 4.5);
+        let third = graph.execute_sync().unwrap();
+        assert!(third.node_outputs.contains_key(&out_path));
+        assert!(ran(&third, sink));
+        assert_eq!(cached(&graph, sink), Some(4.0));
+    }
+
+    // ── Mode parity ───────────────────────────────────────────────
+
+    /// Sequential and Parallel take the same skip decisions.
+    #[test]
+    fn sequential_and_parallel_skip_identically() {
+        for mode in [ExecutionMode::Sequential, ExecutionMode::Parallel] {
+            let (mut graph, num, quant, b, c) = build_chain();
+            graph.execute_sync_with_mode(mode).unwrap();
+
+            set_number(&mut graph, num, 1.7);
+            let second = graph.execute_sync_with_mode(mode).unwrap();
+            assert!(ran(&second, quant), "{mode:?}: the boundary node runs");
+            assert!(
+                !ran(&second, b) && !ran(&second, c),
+                "{mode:?}: its downstream is skipped",
+            );
+
+            set_number(&mut graph, num, 9.9);
+            let third = graph.execute_sync_with_mode(mode).unwrap();
+            assert!(
+                ran(&third, b) && ran(&third, c),
+                "{mode:?}: a real change still propagates",
+            );
+            assert_eq!(cached(&graph, c), Some(9.0));
+        }
     }
 }

--- a/src/node_graph/node_state.rs
+++ b/src/node_graph/node_state.rs
@@ -94,6 +94,10 @@ pub(crate) struct NodeStates {
     output_connections: HashMap<OutputSlotId, Vec<EdgeId>>,
     /// Index: source node → outgoing edge IDs (NodePath-keyed).
     outgoing_edges: HashMap<NodePath, Vec<EdgeId>>,
+    /// Index: sink node → incoming edge IDs (NodePath-keyed). The mirror
+    /// of `outgoing_edges`; lets "who feeds this node?" be answered in
+    /// O(degree) instead of a scan over every input slot in the graph.
+    incoming_edges: HashMap<NodePath, Vec<EdgeId>>,
     /// Nodes changed since last drain (NodePath-keyed for deferred dirty tracking).
     changed_nodes: HashSet<NodePath>,
     /// Hierarchical index: parent NodePath → direct children NodeIds.
@@ -516,6 +520,10 @@ impl NodeStates {
             .entry(edge.from_node.clone())
             .or_default()
             .push(edge_id);
+        self.incoming_edges
+            .entry(edge.to_node.clone())
+            .or_default()
+            .push(edge_id);
         self.edges.insert(edge_id, edge);
     }
 
@@ -531,6 +539,9 @@ impl NodeStates {
             }
             if let Some(outgoing) = self.outgoing_edges.get_mut(&edge.from_node) {
                 outgoing.retain(|id| id != edge_id);
+            }
+            if let Some(incoming) = self.incoming_edges.get_mut(&edge.to_node) {
+                incoming.retain(|id| id != edge_id);
             }
             Some(edge)
         } else {
@@ -625,6 +636,14 @@ impl NodeStates {
         // Mark the target node as changed so the graph re-executes.
         self.changed_nodes.insert(to_node);
         true
+    }
+
+    /// Get incoming edge IDs into a node.
+    pub fn incoming_edges_at(&self, path: &NodePath) -> &[EdgeId] {
+        self.incoming_edges
+            .get(path)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
     }
 
     /// Get outgoing edge IDs from a node.

--- a/src/node_graph/node_state.rs
+++ b/src/node_graph/node_state.rs
@@ -109,11 +109,37 @@ pub(crate) struct NodeStates {
     changed_nodes: HashSet<NodePath>,
     /// Hierarchical index: parent NodePath → direct children NodeIds.
     path_index: PathIndex,
+    /// Monotone counter bumped by every mutation that changes the
+    /// graph's SHAPE — nodes, slots (count, order, label, type) and
+    /// edges. See [`NodeStates::structure_generation`].
+    structure_generation: u64,
 }
 
 impl NodeStates {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// The graph's structural generation: a monotone counter bumped by
+    /// every mutation that changes the graph's SHAPE.
+    ///
+    /// "Shape" is everything a topology query can observe: which nodes
+    /// exist, which slots they carry (count, order, label, data type,
+    /// default value) and which edges connect them. Node *data* writes
+    /// and dirty-marking are deliberately NOT counted — they change what
+    /// a node computes, never how the graph is wired.
+    ///
+    /// Consumers cache graph-shaped projections (membership maps, owner
+    /// maps, port lookups) against this value and rebuild only when it
+    /// moves.
+    pub fn structure_generation(&self) -> u64 {
+        self.structure_generation
+    }
+
+    /// Record one structural mutation. Every `&mut self` method that
+    /// changes the graph's shape calls this exactly once.
+    fn bump_structure(&mut self) {
+        self.structure_generation = self.structure_generation.wrapping_add(1);
     }
 
     /// Add a new node with slot metadata from `SlotDef` arrays.
@@ -126,6 +152,7 @@ impl NodeStates {
         input_defs: &[SlotDef],
         output_defs: &[SlotDef],
     ) {
+        self.bump_structure();
         // Register in path_index so subtree walks can find this node.
         self.path_index.insert(path);
 
@@ -183,6 +210,7 @@ impl NodeStates {
         inspector_visible: bool,
     ) -> usize {
         let index = self.input_slot_count(path);
+        self.bump_structure();
         let slot = InputSlotState {
             id: InputSlotId::new(),
             label,
@@ -203,6 +231,7 @@ impl NodeStates {
         label: &'static str,
         data_type: DataType,
     ) -> usize {
+        self.bump_structure();
         let index = self.output_slot_count(path);
         let slot = OutputSlotState {
             id: OutputSlotId::new(),
@@ -237,6 +266,7 @@ impl NodeStates {
         inspector_visible: bool,
     ) -> usize {
         let index = index.min(self.input_slot_count(path));
+        self.bump_structure();
         let slot = InputSlotState {
             id: InputSlotId::new(),
             label,
@@ -272,6 +302,7 @@ impl NodeStates {
         data_type: DataType,
     ) -> usize {
         let index = index.min(self.output_slot_count(path));
+        self.bump_structure();
         let slot = OutputSlotState {
             id: OutputSlotId::new(),
             label,
@@ -335,6 +366,7 @@ impl NodeStates {
         index: usize,
         visible: bool,
     ) -> bool {
+        self.bump_structure();
         if let Some(slot) = self
             .input_slots
             .get_mut(path)
@@ -355,6 +387,7 @@ impl NodeStates {
         index: usize,
         label: &'static str,
     ) -> bool {
+        self.bump_structure();
         if let Some(slot) = self
             .input_slots
             .get_mut(path)
@@ -375,6 +408,7 @@ impl NodeStates {
         index: usize,
         label: &'static str,
     ) -> bool {
+        self.bump_structure();
         if let Some(slot) = self
             .output_slots
             .get_mut(path)
@@ -395,6 +429,7 @@ impl NodeStates {
     /// calling this — surviving edges keep their `to_input_slot_id`,
     /// only the index is adjusted.
     pub fn remove_input_slot(&mut self, path: &NodePath, index: usize) {
+        self.bump_structure();
         // Remove the slot at index (shifting the rest down) and tear
         // down its reverse-owner entry.
         let Some(slots) = self.input_slots.get_mut(path) else {
@@ -423,6 +458,7 @@ impl NodeStates {
     /// calling this — surviving edges keep their `from_output_slot_id`,
     /// only the index is adjusted.
     pub fn remove_output_slot(&mut self, path: &NodePath, index: usize) {
+        self.bump_structure();
         // Remove the slot at index (shifting the rest down) and tear
         // down its reverse-owner entry.
         let Some(slots) = self.output_slots.get_mut(path) else {
@@ -455,6 +491,7 @@ impl NodeStates {
 
     /// Remove a node, its slot states, and all connected edges.
     pub fn remove_node(&mut self, path: &NodePath) -> Option<NodeState> {
+        self.bump_structure();
         // Tear down the path_index entry.
         self.path_index.remove(path);
 
@@ -493,6 +530,7 @@ impl NodeStates {
         path: &NodePath,
         slot_index: usize,
     ) -> Option<&mut InputSlotState> {
+        self.bump_structure();
         self.input_slots.get_mut(path)?.get_mut(slot_index)
     }
 
@@ -526,6 +564,7 @@ impl NodeStates {
 
     /// Add an edge and update lookup indexes.
     pub fn add_edge(&mut self, edge_id: EdgeId, edge: Edge) {
+        self.bump_structure();
         self.changed_nodes.insert(edge.to_node.clone());
         self.input_connections
             .entry(edge.to_input_slot_id)
@@ -548,6 +587,7 @@ impl NodeStates {
 
     /// Remove an edge and update lookup indexes.
     pub fn remove_edge(&mut self, edge_id: &EdgeId) -> Option<Edge> {
+        self.bump_structure();
         if let Some(edge) = self.edges.remove(edge_id) {
             self.changed_nodes.insert(edge.to_node.clone());
             if let Some(connections) = self.input_connections.get_mut(&edge.to_input_slot_id) {
@@ -570,6 +610,7 @@ impl NodeStates {
 
     /// Remove all edges involving a node at `path`, maintaining all indexes.
     pub fn remove_edges_for_node_at(&mut self, path: &NodePath) {
+        self.bump_structure();
         let edge_ids: Vec<EdgeId> = self
             .edges
             .iter()
@@ -609,6 +650,7 @@ impl NodeStates {
 
     /// Reorder an edge within its output slot's connection list.
     pub fn reorder_output_edge(&mut self, edge_id: &EdgeId, new_index: usize) -> bool {
+        self.bump_structure();
         let Some(edge) = self.edges.get(edge_id) else {
             return false;
         };
@@ -635,6 +677,7 @@ impl NodeStates {
     /// Moves the edge from its current position to `new_index`.
     /// Returns `true` if the reorder was successful.
     pub fn reorder_input_edge(&mut self, edge_id: &EdgeId, new_index: usize) -> bool {
+        self.bump_structure();
         let Some(edge) = self.edges.get(edge_id) else {
             return false;
         };

--- a/src/node_graph/node_state.rs
+++ b/src/node_graph/node_state.rs
@@ -74,10 +74,17 @@ pub(crate) type SharedNodeStates = Arc<RwLock<NodeStates>>;
 pub(crate) struct NodeStates {
     /// Node data by NodePath.
     nodes: HashMap<NodePath, NodeState>,
-    /// Input slot states by (NodePath, slot_index).
-    input_slots: HashMap<(NodePath, usize), InputSlotState>,
-    /// Output slot states by (NodePath, slot_index).
-    output_slots: HashMap<(NodePath, usize), OutputSlotState>,
+    /// Input slot states per node, in slot order.
+    ///
+    /// The `Vec` position IS the slot index, so a node's slots are
+    /// contiguous `0..len` by construction and the count is `Vec::len` —
+    /// O(1), independent of how many nodes the graph holds. A flat
+    /// `(NodePath, usize)`-keyed map cannot answer "how many slots does
+    /// this node have?" without scanning every slot in the graph, which
+    /// makes any per-node sweep quadratic.
+    input_slots: HashMap<NodePath, Vec<InputSlotState>>,
+    /// Output slot states per node, in slot order. See [`Self::input_slots`].
+    output_slots: HashMap<NodePath, Vec<OutputSlotState>>,
     /// Slot-id reverse-owner map: InputSlotId → (owning NodePath, slot_index).
     ///
     /// Kept in lock-step with `input_slots` by every slot insertion/removal path.
@@ -128,29 +135,39 @@ impl NodeStates {
         );
 
         // Initialize input slot states with metadata
-        for (i, def) in input_defs.iter().enumerate() {
-            let slot = InputSlotState {
-                id: InputSlotId::new(),
-                label: def.label,
-                data_type: def.data_type,
-                max_connections: def.max_connections,
-                inspector_visible: def.inspector_visible,
-                default_value: None,
-            };
-            self.input_slot_owner.insert(slot.id, (path.clone(), i));
-            self.input_slots.insert((path.clone(), i), slot);
-        }
+        let inputs: Vec<InputSlotState> = input_defs
+            .iter()
+            .enumerate()
+            .map(|(i, def)| {
+                let slot = InputSlotState {
+                    id: InputSlotId::new(),
+                    label: def.label,
+                    data_type: def.data_type,
+                    max_connections: def.max_connections,
+                    inspector_visible: def.inspector_visible,
+                    default_value: None,
+                };
+                self.input_slot_owner.insert(slot.id, (path.clone(), i));
+                slot
+            })
+            .collect();
+        self.input_slots.insert(path.clone(), inputs);
 
         // Initialize output slot states with metadata
-        for (i, def) in output_defs.iter().enumerate() {
-            let slot = OutputSlotState {
-                id: OutputSlotId::new(),
-                label: def.label,
-                data_type: def.data_type,
-            };
-            self.output_slot_owner.insert(slot.id, (path.clone(), i));
-            self.output_slots.insert((path.clone(), i), slot);
-        }
+        let outputs: Vec<OutputSlotState> = output_defs
+            .iter()
+            .enumerate()
+            .map(|(i, def)| {
+                let slot = OutputSlotState {
+                    id: OutputSlotId::new(),
+                    label: def.label,
+                    data_type: def.data_type,
+                };
+                self.output_slot_owner.insert(slot.id, (path.clone(), i));
+                slot
+            })
+            .collect();
+        self.output_slots.insert(path.clone(), outputs);
 
         // Mark the node as changed.
         self.changed_nodes.insert(path.clone());
@@ -175,7 +192,7 @@ impl NodeStates {
             default_value: None,
         };
         self.input_slot_owner.insert(slot.id, (path.clone(), index));
-        self.input_slots.insert((path.clone(), index), slot);
+        self.input_slots.entry(path.clone()).or_default().push(slot);
         index
     }
 
@@ -194,7 +211,10 @@ impl NodeStates {
         };
         self.output_slot_owner
             .insert(slot.id, (path.clone(), index));
-        self.output_slots.insert((path.clone(), index), slot);
+        self.output_slots
+            .entry(path.clone())
+            .or_default()
+            .push(slot);
         index
     }
 
@@ -216,16 +236,7 @@ impl NodeStates {
         max_connections: Option<usize>,
         inspector_visible: bool,
     ) -> usize {
-        let count = self.input_slot_count(path);
-        let index = index.min(count);
-        // Shift slots [index..count) up by 1, top-down, updating
-        // reverse-owner indices.
-        for i in (index..count).rev() {
-            if let Some(slot) = self.input_slots.remove(&(path.clone(), i)) {
-                self.input_slot_owner.insert(slot.id, (path.clone(), i + 1));
-                self.input_slots.insert((path.clone(), i + 1), slot);
-            }
-        }
+        let index = index.min(self.input_slot_count(path));
         let slot = InputSlotState {
             id: InputSlotId::new(),
             label,
@@ -234,16 +245,16 @@ impl NodeStates {
             inspector_visible,
             default_value: None,
         };
-        self.input_slot_owner.insert(slot.id, (path.clone(), index));
-        self.input_slots.insert((path.clone(), index), slot);
+        self.input_slots
+            .entry(path.clone())
+            .or_default()
+            .insert(index, slot);
+        self.reindex_input_slot_owners(path, index);
         // Increment to_input_slot_index on edges referencing shifted
         // slots so indices stay aligned (mirror of remove's decrement).
         for edge in self.edges.values_mut() {
             if edge.to_node == *path && edge.to_input_slot_index >= index {
                 edge.to_input_slot_index += 1;
-                if let Some(entry) = self.input_slot_owner.get_mut(&edge.to_input_slot_id) {
-                    entry.1 = edge.to_input_slot_index;
-                }
             }
         }
         index
@@ -260,32 +271,60 @@ impl NodeStates {
         label: &'static str,
         data_type: DataType,
     ) -> usize {
-        let count = self.output_slot_count(path);
-        let index = index.min(count);
-        for i in (index..count).rev() {
-            if let Some(slot) = self.output_slots.remove(&(path.clone(), i)) {
-                self.output_slot_owner
-                    .insert(slot.id, (path.clone(), i + 1));
-                self.output_slots.insert((path.clone(), i + 1), slot);
-            }
-        }
+        let index = index.min(self.output_slot_count(path));
         let slot = OutputSlotState {
             id: OutputSlotId::new(),
             label,
             data_type,
         };
-        self.output_slot_owner
-            .insert(slot.id, (path.clone(), index));
-        self.output_slots.insert((path.clone(), index), slot);
+        self.output_slots
+            .entry(path.clone())
+            .or_default()
+            .insert(index, slot);
+        self.reindex_output_slot_owners(path, index);
         for edge in self.edges.values_mut() {
             if edge.from_node == *path && edge.from_output_slot_index >= index {
                 edge.from_output_slot_index += 1;
-                if let Some(entry) = self.output_slot_owner.get_mut(&edge.from_output_slot_id) {
-                    entry.1 = edge.from_output_slot_index;
-                }
             }
         }
         index
+    }
+
+    /// Rewrite `input_slot_owner` for every slot of `path` from `from`
+    /// onward, read straight off the authoritative slot `Vec`.
+    ///
+    /// The `Vec` position IS the slot index, so this is the single place
+    /// that restates it into the reverse-owner map after an insert or a
+    /// remove shifted positions.
+    fn reindex_input_slot_owners(&mut self, path: &NodePath, from: usize) {
+        let entries: Vec<(InputSlotId, usize)> =
+            self.input_slots.get(path).map_or_else(Vec::new, |slots| {
+                slots
+                    .iter()
+                    .enumerate()
+                    .skip(from)
+                    .map(|(index, slot)| (slot.id, index))
+                    .collect()
+            });
+        for (id, index) in entries {
+            self.input_slot_owner.insert(id, (path.clone(), index));
+        }
+    }
+
+    /// Output-side mirror of [`Self::reindex_input_slot_owners`].
+    fn reindex_output_slot_owners(&mut self, path: &NodePath, from: usize) {
+        let entries: Vec<(OutputSlotId, usize)> =
+            self.output_slots.get(path).map_or_else(Vec::new, |slots| {
+                slots
+                    .iter()
+                    .enumerate()
+                    .skip(from)
+                    .map(|(index, slot)| (slot.id, index))
+                    .collect()
+            });
+        for (id, index) in entries {
+            self.output_slot_owner.insert(id, (path.clone(), index));
+        }
     }
 
     /// Rewrite the `inspector_visible` flag of an input slot. Returns
@@ -296,7 +335,11 @@ impl NodeStates {
         index: usize,
         visible: bool,
     ) -> bool {
-        if let Some(slot) = self.input_slots.get_mut(&(path.clone(), index)) {
+        if let Some(slot) = self
+            .input_slots
+            .get_mut(path)
+            .and_then(|slots| slots.get_mut(index))
+        {
             slot.inspector_visible = visible;
             true
         } else {
@@ -312,7 +355,11 @@ impl NodeStates {
         index: usize,
         label: &'static str,
     ) -> bool {
-        if let Some(slot) = self.input_slots.get_mut(&(path.clone(), index)) {
+        if let Some(slot) = self
+            .input_slots
+            .get_mut(path)
+            .and_then(|slots| slots.get_mut(index))
+        {
             slot.label = label;
             true
         } else {
@@ -328,7 +375,11 @@ impl NodeStates {
         index: usize,
         label: &'static str,
     ) -> bool {
-        if let Some(slot) = self.output_slots.get_mut(&(path.clone(), index)) {
+        if let Some(slot) = self
+            .output_slots
+            .get_mut(path)
+            .and_then(|slots| slots.get_mut(index))
+        {
             slot.label = label;
             true
         } else {
@@ -344,30 +395,22 @@ impl NodeStates {
     /// calling this — surviving edges keep their `to_input_slot_id`,
     /// only the index is adjusted.
     pub fn remove_input_slot(&mut self, path: &NodePath, index: usize) {
-        let count = self.input_slot_count(path);
-        if index >= count {
+        // Remove the slot at index (shifting the rest down) and tear
+        // down its reverse-owner entry.
+        let Some(slots) = self.input_slots.get_mut(path) else {
+            return;
+        };
+        if index >= slots.len() {
             return;
         }
-        // Remove the slot at index and tear down its reverse-owner entry.
-        if let Some(slot) = self.input_slots.remove(&(path.clone(), index)) {
-            self.input_slot_owner.remove(&slot.id);
-        }
-        // Shift slots above index down by 1, updating reverse-owner indices.
-        for i in (index + 1)..count {
-            if let Some(slot) = self.input_slots.remove(&(path.clone(), i)) {
-                self.input_slot_owner.insert(slot.id, (path.clone(), i - 1));
-                self.input_slots.insert((path.clone(), i - 1), slot);
-            }
-        }
+        let removed = slots.remove(index);
+        self.input_slot_owner.remove(&removed.id);
+        self.reindex_input_slot_owners(path, index);
         // Decrement to_input_slot_index on edges that reference this
         // node's higher-indexed input slots so indices stay aligned.
         for edge in self.edges.values_mut() {
             if edge.to_node == *path && edge.to_input_slot_index > index {
                 edge.to_input_slot_index -= 1;
-                // Update the reverse-owner index for the shifted slot.
-                if let Some(entry) = self.input_slot_owner.get_mut(&edge.to_input_slot_id) {
-                    entry.1 = edge.to_input_slot_index;
-                }
             }
         }
     }
@@ -380,43 +423,34 @@ impl NodeStates {
     /// calling this — surviving edges keep their `from_output_slot_id`,
     /// only the index is adjusted.
     pub fn remove_output_slot(&mut self, path: &NodePath, index: usize) {
-        let count = self.output_slot_count(path);
-        if index >= count {
+        // Remove the slot at index (shifting the rest down) and tear
+        // down its reverse-owner entry.
+        let Some(slots) = self.output_slots.get_mut(path) else {
+            return;
+        };
+        if index >= slots.len() {
             return;
         }
-        // Remove the slot at index and tear down its reverse-owner entry.
-        if let Some(slot) = self.output_slots.remove(&(path.clone(), index)) {
-            self.output_slot_owner.remove(&slot.id);
-        }
-        // Shift slots above index down by 1, updating reverse-owner indices.
-        for i in (index + 1)..count {
-            if let Some(slot) = self.output_slots.remove(&(path.clone(), i)) {
-                self.output_slot_owner
-                    .insert(slot.id, (path.clone(), i - 1));
-                self.output_slots.insert((path.clone(), i - 1), slot);
-            }
-        }
+        let removed = slots.remove(index);
+        self.output_slot_owner.remove(&removed.id);
+        self.reindex_output_slot_owners(path, index);
         // Decrement from_output_slot_index on edges that reference this
         // node's higher-indexed output slots so indices stay aligned.
         for edge in self.edges.values_mut() {
             if edge.from_node == *path && edge.from_output_slot_index > index {
                 edge.from_output_slot_index -= 1;
-                // Update the reverse-owner index for the shifted slot.
-                if let Some(entry) = self.output_slot_owner.get_mut(&edge.from_output_slot_id) {
-                    entry.1 = edge.from_output_slot_index;
-                }
             }
         }
     }
 
-    /// Count input slots for a node.
+    /// Count input slots for a node — O(1), one hash lookup.
     pub fn input_slot_count(&self, path: &NodePath) -> usize {
-        self.input_slots.keys().filter(|(p, _)| p == path).count()
+        self.input_slots.get(path).map_or(0, Vec::len)
     }
 
-    /// Count output slots for a node.
+    /// Count output slots for a node — O(1), one hash lookup.
     pub fn output_slot_count(&self, path: &NodePath) -> usize {
-        self.output_slots.keys().filter(|(p, _)| p == path).count()
+        self.output_slots.get(path).map_or(0, Vec::len)
     }
 
     /// Remove a node, its slot states, and all connected edges.
@@ -428,27 +462,12 @@ impl NodeStates {
         self.remove_edges_for_node_at(path);
 
         // Remove slot states and tear down reverse-owner entries.
-        let input_ids: Vec<InputSlotId> = self
-            .input_slots
-            .iter()
-            .filter(|((p, _), _)| p == path)
-            .map(|(_, s)| s.id)
-            .collect();
-        for id in input_ids {
-            self.input_slot_owner.remove(&id);
+        for slot in self.input_slots.remove(path).unwrap_or_default() {
+            self.input_slot_owner.remove(&slot.id);
         }
-        self.input_slots.retain(|(p, _), _| p != path);
-
-        let output_ids: Vec<OutputSlotId> = self
-            .output_slots
-            .iter()
-            .filter(|((p, _), _)| p == path)
-            .map(|(_, s)| s.id)
-            .collect();
-        for id in output_ids {
-            self.output_slot_owner.remove(&id);
+        for slot in self.output_slots.remove(path).unwrap_or_default() {
+            self.output_slot_owner.remove(&slot.id);
         }
-        self.output_slots.retain(|(p, _), _| p != path);
 
         self.nodes.remove(path)
     }
@@ -465,7 +484,7 @@ impl NodeStates {
 
     /// Get input slot state.
     pub fn input_slot(&self, path: &NodePath, slot_index: usize) -> Option<&InputSlotState> {
-        self.input_slots.get(&(path.clone(), slot_index))
+        self.input_slots.get(path)?.get(slot_index)
     }
 
     /// Get mutable input slot state.
@@ -474,12 +493,12 @@ impl NodeStates {
         path: &NodePath,
         slot_index: usize,
     ) -> Option<&mut InputSlotState> {
-        self.input_slots.get_mut(&(path.clone(), slot_index))
+        self.input_slots.get_mut(path)?.get_mut(slot_index)
     }
 
     /// Get output slot state.
     pub fn output_slot(&self, path: &NodePath, slot_index: usize) -> Option<&OutputSlotState> {
-        self.output_slots.get(&(path.clone(), slot_index))
+        self.output_slots.get(path)?.get(slot_index)
     }
 
     /// Look up the owning `(NodePath, slot_index)` for an `InputSlotId`.


### PR DESCRIPTION
## Summary

Support for revion's live-graph-commit program (AltrixHub/revion#297): gestures now commit to the main graph per tick, so execution must stop where values stop changing, and downstream caches need a cheap structural-change key.

## Changes

- Add opt-in `OutputCutoff`: a node can declare output equivalence so an unchanged output prunes the change frontier (InterfaceNode boundaries are resolved through, like the value resolver)
- Store slot state as per-node vectors and add an `incoming_edges` reverse index (removes O(graph) scans on the hot execution path)
- Expose `structure_generation()`: a counter bumped on structural mutation, used by revion to key delta-maintained projections

## Notes

Merge together with the revion PR of the same branch name; revion pins this crate by path in the fork workspace.
