### PR TITLE
perf(graph): Degrade small parallel plans + evict removed nodes' cache

### DIFF
--- a/src/node_graph/mod.rs
+++ b/src/node_graph/mod.rs
@@ -137,6 +137,25 @@ impl NodeGraph {
         }
     }
 
+    /// Drop every error targeting `node_id` (the node itself or one of
+    /// its ports). Called by node removal: an error for a node that no
+    /// longer exists can never be cleared by a later run — its target
+    /// never executes again — so it would otherwise sit in the map (and
+    /// ride every [`Self::errors`] snapshot) forever.
+    pub(crate) fn clear_errors_for_node(&self, node_id: NodeId) {
+        if let Ok(mut b) = self.bookkeeping.lock() {
+            b.errors.retain(|target, _| {
+                !matches!(
+                    target,
+                    ErrorTarget::Node(id)
+                    | ErrorTarget::InputPort { node_id: id, .. }
+                    | ErrorTarget::OutputPort { node_id: id, .. }
+                    if *id == node_id
+                )
+            });
+        }
+    }
+
     /// Mark all nodes in the graph as dirty, forcing re-execution.
     pub fn mark_all_nodes_dirty(&self) {
         if let Ok(mut ns) = self.node_states.write() {

--- a/src/node_graph/node_graph_api.rs
+++ b/src/node_graph/node_graph_api.rs
@@ -696,10 +696,27 @@ impl NodeGraphWrite for NodeGraph {
 
     fn remove_node(&mut self, node_id: NodeId) -> Result<(), String> {
         if self.node_manager.node_remove(&node_id).is_some() {
+            let path = NodePath::root().child(node_id);
+            // The node's output slot ids key the execution cache and are
+            // unrecoverable once the slot tables are gone.
+            let removed_output_slots: Vec<crate::OutputSlotId> = {
+                let ns = self.node_states.read().map_err(|e| e.to_string())?;
+                (0..ns.output_slot_count(&path))
+                    .filter_map(|index| ns.output_slot(&path, index).map(|slot| slot.id))
+                    .collect()
+            };
             {
                 let mut guard = self.node_states.write().map_err(|e| e.to_string())?;
-                guard.remove_node(&NodePath::root().child(node_id)); // remove_edge auto-tracks downstream
+                guard.remove_node(&path); // remove_edge auto-tracks downstream
             }
+            // Evict the cached outputs and the errors nothing could ever
+            // clear again — see `remove_node_at`.
+            if let Ok(mut cache) = self.cache.lock() {
+                for slot in &removed_output_slots {
+                    cache.outputs.remove(slot);
+                }
+            }
+            self.clear_errors_for_node(node_id);
             self.record_removal(node_id);
             Ok(())
         } else {
@@ -818,6 +835,41 @@ fn validate_async_in_sync_plan(
         Err(GraphExecutionError::RequiresAsyncExecution {
             node_ids: async_nodes,
         })
+    }
+}
+
+/// Plans smaller than this run sequentially even when the caller asked
+/// for [`ExecutionMode::Parallel`].
+///
+/// Gesture-scale dirty cones (tens of nodes, deep and narrow) lose more
+/// to the level-synchronous rayon fan-out — a barrier per topological
+/// level, the shared cache / node-map locks contended from every worker
+/// — than they gain from parallelism (measured 5–20% on the modeling
+/// app's node-scaling survey; up to 2× before its app-layer scans were
+/// removed). The two thresholds bound the two loss modes: a small plan
+/// cannot amortise the fan-out at all, and a narrow one pays a barrier
+/// per level for almost no concurrent work.
+const PARALLEL_MIN_PLAN_NODES: usize = 64;
+/// See [`PARALLEL_MIN_PLAN_NODES`] — the widest level must offer at
+/// least this much concurrent work.
+const PARALLEL_MIN_LEVEL_WIDTH: usize = 4;
+
+/// Degrade a [`ExecutionMode::Parallel`] request to `Sequential` when
+/// `plan` is too small or too narrow to profit from the fan-out.
+/// `Sequential` requests pass through untouched.
+fn effective_mode(plan: &ExecutionPlan, requested: ExecutionMode) -> ExecutionMode {
+    match requested {
+        ExecutionMode::Parallel => {
+            let max_width = plan.levels.iter().map(Vec::len).max().unwrap_or(0);
+            if plan.planned_node_paths.len() < PARALLEL_MIN_PLAN_NODES
+                || max_width < PARALLEL_MIN_LEVEL_WIDTH
+            {
+                ExecutionMode::Sequential
+            } else {
+                ExecutionMode::Parallel
+            }
+        }
+        ExecutionMode::Sequential => ExecutionMode::Sequential,
     }
 }
 
@@ -1459,6 +1511,7 @@ impl NodeGraph {
         on_progress: Arc<dyn Fn(ExecutionEvent) + Send + Sync>,
     ) -> Result<ExecutionResult, GraphExecutionError> {
         let plan = self.build_execution_plan()?;
+        let mode = effective_mode(&plan, mode);
 
         tracing::debug!(
             target: "graph",
@@ -1583,6 +1636,7 @@ impl NodeGraph {
         on_progress: Arc<dyn Fn(ExecutionEvent) + Send + Sync>,
     ) -> Result<ExecutionResult, GraphExecutionError> {
         let plan = self.build_execution_plan()?;
+        let mode = effective_mode(&plan, mode);
 
         tracing::debug!(
             target: "graph",
@@ -1856,6 +1910,99 @@ mod sync_executor_tests {
         let (graph, _, _, add_id) = build_add_graph(7.0, 8.0);
         let result = graph.execute_sync().unwrap();
         assert_eq!(output_for(&result, add_id), 15.0);
+    }
+
+    /// Removing a node evicts its cached outputs: nothing can ever read
+    /// them again (the slot ids die with the slot tables), and mesh-grade
+    /// Arc payloads would otherwise stay resident for the session.
+    #[test]
+    fn removal_evicts_the_nodes_cached_outputs() {
+        let (mut graph, a_id, _, _) = build_add_graph(1.0, 2.0);
+        graph.execute_sync().unwrap();
+
+        let a_slot = {
+            let ns = graph.node_states.read().unwrap();
+            ns.output_slot(&NodePath::root().child(a_id), 0).unwrap().id
+        };
+        assert!(
+            graph
+                .shared_cache()
+                .read()
+                .unwrap()
+                .get_output(&a_slot)
+                .is_some(),
+            "the executed output must be cached before the removal"
+        );
+
+        graph.remove_node(a_id).unwrap();
+        assert!(
+            graph
+                .shared_cache()
+                .read()
+                .unwrap()
+                .get_output(&a_slot)
+                .is_none(),
+            "a removed node's cached outputs must be evicted"
+        );
+    }
+
+    /// Removing a node drops the errors targeting it — no later run can
+    /// clear them, so they would otherwise accumulate forever.
+    #[test]
+    fn removal_drops_the_nodes_errors() {
+        let (mut graph, a_id, b_id, _) = build_add_graph(1.0, 2.0);
+        graph.add_error(GraphError::execution(a_id, "boom"));
+        graph.add_error(GraphError::execution(b_id, "kept"));
+
+        graph.remove_node(a_id).unwrap();
+        let errors = graph.errors();
+        assert!(!errors.contains_key(&ErrorTarget::Node(a_id)));
+        assert!(errors.contains_key(&ErrorTarget::Node(b_id)));
+    }
+
+    /// A gesture-scale plan (small / narrow) degrades a Parallel request
+    /// to Sequential; a wide-enough plan keeps it.
+    #[test]
+    fn effective_mode_degrades_small_and_narrow_plans() {
+        let plan_of = |widths: &[usize]| ExecutionPlan {
+            seed_nodes: HashSet::new(),
+            dirty_nodes: HashSet::new(),
+            levels: widths
+                .iter()
+                .map(|w| {
+                    (0..*w)
+                        .map(|_| NodePath::root().child(NodeId::new()))
+                        .collect()
+                })
+                .collect(),
+            planned_node_paths: (0..widths.iter().sum::<usize>())
+                .map(|_| NodePath::root().child(NodeId::new()))
+                .collect(),
+            removed_nodes: Vec::new(),
+        };
+        // Deep and narrow: plenty of nodes, no concurrent work per level.
+        let narrow = plan_of(&vec![2; 50]);
+        assert_eq!(
+            effective_mode(&narrow, ExecutionMode::Parallel),
+            ExecutionMode::Sequential,
+        );
+        // Small: too few nodes to amortise the fan-out.
+        let small = plan_of(&[10, 10]);
+        assert_eq!(
+            effective_mode(&small, ExecutionMode::Parallel),
+            ExecutionMode::Sequential,
+        );
+        // Big and wide: the fan-out pays.
+        let wide = plan_of(&vec![16; 8]);
+        assert_eq!(
+            effective_mode(&wide, ExecutionMode::Parallel),
+            ExecutionMode::Parallel,
+        );
+        // A Sequential request is never upgraded.
+        assert_eq!(
+            effective_mode(&wide, ExecutionMode::Sequential),
+            ExecutionMode::Sequential,
+        );
     }
 
     /// A plain removal (no re-creation) is reported in `removed_nodes`.

--- a/src/node_graph/path_api.rs
+++ b/src/node_graph/path_api.rs
@@ -841,22 +841,46 @@ impl NodeGraph {
     /// each path: drops edges, drops slots, drops NodeStates entry,
     /// drops NodeManager entry.
     pub fn remove_node_at(&mut self, path: &NodePath) -> Result<(), String> {
-        // Collect all paths under (and including) `path`, leaves first.
-        let all_paths = {
+        // Collect all paths under (and including) `path`, leaves first —
+        // plus the subtree's output slot ids, which key the execution
+        // cache and are unrecoverable once the slot tables are gone.
+        let (all_paths, removed_output_slots) = {
             let ns = self.node_states.read().map_err(|e| e.to_string())?;
-            collect_subtree_paths(&ns, path)
+            let all_paths = collect_subtree_paths(&ns, path);
+            let slots: Vec<crate::OutputSlotId> = all_paths
+                .iter()
+                .flat_map(|p| {
+                    (0..ns.output_slot_count(p))
+                        .filter_map(|index| ns.output_slot(p, index).map(|slot| slot.id))
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+            (all_paths, slots)
         };
 
-        let mut ns = self.node_states.write().map_err(|e| e.to_string())?;
-        for p in &all_paths {
-            // Drop edges connected to this node.
-            ns.remove_edges_for_node_at(p);
-            let _ = self.remove_node_at_locked(&mut ns, p);
+        {
+            let mut ns = self.node_states.write().map_err(|e| e.to_string())?;
+            for p in &all_paths {
+                // Drop edges connected to this node.
+                ns.remove_edges_for_node_at(p);
+                let _ = self.remove_node_at_locked(&mut ns, p);
+            }
+        }
+
+        // Evict the removed subtree's cached outputs — mesh-grade Arc
+        // payloads a session with deletions would otherwise retain
+        // forever — and every error targeting it, which no later run
+        // could ever clear.
+        if let Ok(mut cache) = self.cache.lock() {
+            for slot in &removed_output_slots {
+                cache.outputs.remove(slot);
+            }
         }
 
         // Record removals for execution result reporting.
         for p in &all_paths {
             if let Some(id) = p.leaf() {
+                self.clear_errors_for_node(id);
                 self.record_removal(id);
             }
         }


### PR DESCRIPTION
## Summary

Two executor-side fixes from the modeling app's node-scaling survey (revion perf program, companion to revion #310/#311/#312 — no ordering constraint, revion PRs build against either side):

**Sequential fallback for gesture-scale plans.** Level-synchronous rayon pays a barrier per topological level plus the shared cache / node-map locks from every worker; deep-and-narrow gesture cones (tens of nodes) lose more than they gain. A `Parallel` request now degrades to `Sequential` when the plan has < 64 nodes or its widest level < 4 concurrent nodes. Survey numbers: creation cursor tick p50 **0.73 → 0.46 ms (−37%)**, drag ticks −6…−13%, structural commits −3…−8%; wide plans (307-node slab cones) keep rayon and are unchanged. (The survey's original 1.7–2.2× single-core advantage largely disappeared once revion's app-layer scans were removed in #310 — the remaining win is the honest executor-side margin.)

**Eviction on removal.** `remove_node` / `remove_node_at` left the removed nodes' outputs in the `ExecutionCache` forever (mesh-grade `Arc` payloads keyed by slot ids nothing can ever read again) and left their errors in the bookkeeping map (an error whose target never executes again can never be cleared). Both are torn down with the node — the engine-side source of the survey's monotonic RSS growth in delete-heavy sessions.

## Test plan

- `cargo nextest run`: 163/163 (3 new tests: cache eviction on removal, error eviction on removal, `effective_mode` degrade/keep matrix)
- revion modeling app suite against this branch: 4,173 passed; node-scaling survey re-run before/after for the numbers above